### PR TITLE
Scale Widget

### DIFF
--- a/packages/widgets/src/components/Scale.jsx
+++ b/packages/widgets/src/components/Scale.jsx
@@ -5,7 +5,7 @@ import { RadioGroup, FormControl, FormLabel,
 
 
 // for now set here - might this differ for different scales, or always 7...?
-const scale_options = 7
+const number_of_options = 7
 
 
 
@@ -31,7 +31,7 @@ const Scale = ({ handleIntDataChange, intData, item }) => (
 
       {
           Array.from(
-              {length: scale_options},
+              {length: number_of_options},
               (v, i) => i+1
           ).map(
               number => (

--- a/packages/widgets/src/components/Scale.jsx
+++ b/packages/widgets/src/components/Scale.jsx
@@ -1,75 +1,56 @@
-import React, {Component} from 'react'
-import { RadioGroup, FormControl, FormLabel, FormControlLabel, Radio } from "@material-ui/core"
+import React from 'react'
+import { RadioGroup, FormControl, FormLabel, FormControlLabel, Radio, Grid } from "@material-ui/core"
 
 
-// for now set here - might this differ for different scales, or alway
+// for now set here - might this differ for different scales, or always 7...?
 const scale_options = 7
 
-class Scale extends Component {
-
-    constructor(props){
-        super(props)
-        this.state = {
-            value: "1"
-        }
-    }
 
 
-    handleChange = (event) => {
-        this.setState({value: event.target.value})
-    }
+const Scale = ({ handleIntOptionChange, intData, title }) => (
 
-    render()
-    {
-        return (
+    <div>
+    <FormControl fullWidth component="fieldset">
 
-        <div>
-        <FormControl component="fieldset">
-          <FormLabel component="legend">{this.props.title}</FormLabel>
-          <RadioGroup
-          row={true}
-            aria-label="agreement"
-            name="agreement"
-            value={this.state.value}
-            onChange={this.handleChange}
-          >
+    <Grid container >
 
-          {
-              Array.from(
-                  {length: scale_options},
-                  (v, i) => i+1
-              ).map(
-                  number => (
-                      <FormControlLabel
-                      key={number}
-                      value={"" + number}
-                      control={<Radio color="primary" />} 
-                      label={"" + number}
-                      labelPlacement="top"
-                      />
-                  
-              ))
-          }
+    <Grid item xs={4}>
+      <FormLabel component="legend">{title}</FormLabel>
+    </Grid>
 
+    <Grid item xs>
+      <RadioGroup 
+        row
+        aria-label="agreement"
+        name="agreement"
+        value={`${intData}`}
+        onChange={handleIntOptionChange}
+      >
 
-
-          </RadioGroup>
-        </FormControl>
-        </div>
-       )
-    }}
+      {
+          Array.from(
+              {length: scale_options},
+              (v, i) => i+1
+          ).map(
+              number => (
+                  <FormControlLabel
+                  key={number}
+                  value={`${number}`}
+                  control={<Radio color="primary" />} 
+                  label={`${number}`}
+                  labelPlacement="start"
+                  />
+              
+          ))
+      }
 
 
-    const ScaleOption = ({ arvo }) => (
-        <FormControlLabel
-            value={arvo}
-            control={<Radio color="primary" />} 
-            label={arvo}
-            labelPlacement="top"
-            />
-            
-    )
+        </RadioGroup>
+      </Grid>      
+    </Grid>
 
-
+    </FormControl>
+    </div>
+   )
 
 export default Scale

--- a/packages/widgets/src/components/Scale.jsx
+++ b/packages/widgets/src/components/Scale.jsx
@@ -21,7 +21,7 @@ const Scale = ({ handleIntDataChange,
 
     <Grid container >
 
-    <Grid item xs={4}>
+    <Grid item xs={4} style={{alignSelf: "center"}}>
       <FormLabel component="legend" ><Typography variant="subtitle1">{item.texts[0].title}</Typography></FormLabel>
     </Grid>
 

--- a/packages/widgets/src/components/Scale.jsx
+++ b/packages/widgets/src/components/Scale.jsx
@@ -1,11 +1,11 @@
 import React from 'react'
-import { RadioGroup, FormControl, FormLabel,
-   FormControlLabel, Radio, Grid,
+import { FormControl, FormLabel, FormControlLabel,
+  Radio, RadioGroup,
+  Table, TableBody, TableCell, TableRow,
   Typography } from "@material-ui/core"
 
 
-// for now set here - might this differ for different scales, or always 7...?
-const number_of_options = 7
+const NUMBER_OF_OPTIONS = 7
 
 
 
@@ -19,13 +19,15 @@ const Scale = ({ handleIntDataChange,
     <div>
     <FormControl fullWidth component="fieldset">
 
-    <Grid container >
+    <Table>
+      <TableBody>
+      <TableRow>
 
-    <Grid item xs={4} style={{alignSelf: "center"}}>
+    <TableCell style={{width: "40%"}}>
       <FormLabel component="legend" ><Typography variant="subtitle1">{item.texts[0].title}</Typography></FormLabel>
-    </Grid>
+    </TableCell>
 
-    <Grid item xs>
+    <TableCell style={{width: "40%"}}>
       <RadioGroup 
         row
         aria-label="agreement"
@@ -36,7 +38,7 @@ const Scale = ({ handleIntDataChange,
 
       {
           Array.from(
-              {length: number_of_options},
+              {length: NUMBER_OF_OPTIONS},
               (v, i) => i+1
           ).map(
               number => (
@@ -52,11 +54,11 @@ const Scale = ({ handleIntDataChange,
               
           ))
       }
-
-
         </RadioGroup>
-      </Grid>      
-    </Grid>
+      </TableCell>   
+      </TableRow>   
+      </TableBody>
+    </Table>
 
     </FormControl>
     </div>

--- a/packages/widgets/src/components/Scale.jsx
+++ b/packages/widgets/src/components/Scale.jsx
@@ -9,15 +9,20 @@ const number_of_options = 7
 
 
 
-const Scale = ({ handleIntDataChange, intData, item }) => (
+const Scale = ({ handleIntDataChange,
+   intData,
+    item,
+  answered }) => {
 
+    
+    return (
     <div>
     <FormControl fullWidth component="fieldset">
 
     <Grid container >
 
     <Grid item xs={4}>
-      <FormLabel component="legend"><Typography variant="subtitle1">{item.texts[0].title}</Typography></FormLabel>
+      <FormLabel component="legend" ><Typography variant="subtitle1">{item.texts[0].title}</Typography></FormLabel>
     </Grid>
 
     <Grid item xs>
@@ -39,9 +44,7 @@ const Scale = ({ handleIntDataChange, intData, item }) => (
                   key={number}
                   value={`${number}`}
                   control={
-                    <Radio color="primary" style={{
-                      paddingLeft: 0
-                    }} />
+                    <Radio {...radioButtonOptions(answered)} />
                   } 
                   label={`${number}`}
                   labelPlacement="start"
@@ -58,5 +61,20 @@ const Scale = ({ handleIntDataChange, intData, item }) => (
     </FormControl>
     </div>
    )
+  }
+
+  const radioButtonOptions = (answered) => {
+    let options = {
+      style: {
+        paddingLeft: 0,
+      }, 
+      color: answered ? "default" : "primary"
+    }
+
+    if(answered){
+      options.onChange=null
+    }
+    return options
+  }
 
 export default Scale

--- a/packages/widgets/src/components/Scale.jsx
+++ b/packages/widgets/src/components/Scale.jsx
@@ -1,5 +1,7 @@
 import React from 'react'
-import { RadioGroup, FormControl, FormLabel, FormControlLabel, Radio, Grid } from "@material-ui/core"
+import { RadioGroup, FormControl, FormLabel,
+   FormControlLabel, Radio, Grid,
+  Typography } from "@material-ui/core"
 
 
 // for now set here - might this differ for different scales, or always 7...?
@@ -7,7 +9,7 @@ const scale_options = 7
 
 
 
-const Scale = ({ handleIntOptionChange, intData, title }) => (
+const Scale = ({ handleIntOptionChange, intData, item }) => (
 
     <div>
     <FormControl fullWidth component="fieldset">
@@ -15,7 +17,7 @@ const Scale = ({ handleIntOptionChange, intData, title }) => (
     <Grid container >
 
     <Grid item xs={4}>
-      <FormLabel component="legend">{title}</FormLabel>
+      <FormLabel component="legend"><Typography variant="subtitle1">{item.texts[0].title}</Typography></FormLabel>
     </Grid>
 
     <Grid item xs>
@@ -36,7 +38,11 @@ const Scale = ({ handleIntOptionChange, intData, title }) => (
                   <FormControlLabel
                   key={number}
                   value={`${number}`}
-                  control={<Radio color="primary" />} 
+                  control={
+                    <Radio color="primary" style={{
+                      paddingLeft: 0
+                    }} />
+                  } 
                   label={`${number}`}
                   labelPlacement="start"
                   />

--- a/packages/widgets/src/components/Scale.jsx
+++ b/packages/widgets/src/components/Scale.jsx
@@ -1,0 +1,75 @@
+import React, {Component} from 'react'
+import { RadioGroup, FormControl, FormLabel, FormControlLabel, Radio } from "@material-ui/core"
+
+
+// for now set here - might this differ for different scales, or alway
+const scale_options = 7
+
+class Scale extends Component {
+
+    constructor(props){
+        super(props)
+        this.state = {
+            value: "1"
+        }
+    }
+
+
+    handleChange = (event) => {
+        this.setState({value: event.target.value})
+    }
+
+    render()
+    {
+        return (
+
+        <div>
+        <FormControl component="fieldset">
+          <FormLabel component="legend">{this.props.title}</FormLabel>
+          <RadioGroup
+          row={true}
+            aria-label="agreement"
+            name="agreement"
+            value={this.state.value}
+            onChange={this.handleChange}
+          >
+
+          {
+              Array.from(
+                  {length: scale_options},
+                  (v, i) => i+1
+              ).map(
+                  number => (
+                      <FormControlLabel
+                      key={number}
+                      value={"" + number}
+                      control={<Radio color="primary" />} 
+                      label={"" + number}
+                      labelPlacement="top"
+                      />
+                  
+              ))
+          }
+
+
+
+          </RadioGroup>
+        </FormControl>
+        </div>
+       )
+    }}
+
+
+    const ScaleOption = ({ arvo }) => (
+        <FormControlLabel
+            value={arvo}
+            control={<Radio color="primary" />} 
+            label={arvo}
+            labelPlacement="top"
+            />
+            
+    )
+
+
+
+export default Scale

--- a/packages/widgets/src/components/Unsupported.jsx
+++ b/packages/widgets/src/components/Unsupported.jsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default ({item}) => (
+    <div>{`Quiz of type '${item.type}' is not supported yet`}</div>
+)

--- a/packages/widgets/src/components/index.jsx
+++ b/packages/widgets/src/components/index.jsx
@@ -3,7 +3,9 @@ import { Button, Typography } from "@material-ui/core"
 import Essay from "./Essay"
 import MultipleChoice from "./MultipleChoice"
 import Scale from './Scale'
+import Unsupported from './Unsupported'
 import axios from "axios"
+
 
 const mapTypeToComponent = {
   essay: Essay,
@@ -11,8 +13,13 @@ const mapTypeToComponent = {
   scale: Scale
 }
 
+const componentType = (typeName) => {
+  let component = mapTypeToComponent[typeName]
+  return component === undefined ? Unsupported : component
+}
+
 const ids = {
-  scale_id: "2684de7b-f52a-4411-a96f-c4f996bc6f4f",
+  scale_id: "23558109-e0e4-4a2c-b85a-b4b00d2d3cdf",
   essay_id: "4901fd41-2e77-4c3f-a2d9-255582fca7b6",
   multiple_choice_id: "4bf4cf2f-3058-4311-8d16-26d781261af7"
 }
@@ -112,9 +119,9 @@ class Quiz extends Component {
         <div>
           <Typography variant="body1" dangerouslySetInnerHTML={{ __html: this.state.quiz.texts[0].body }} />
           {this.state.quiz.items.map(item => {
-            const ItemComponent = mapTypeToComponent[item.type]
+            const ItemComponent = componentType(item.type) 
             return <ItemComponent
-              title={item.texts[0].title}
+              item={item}
               quizId={id}
               key={item.id}
               accessToken={accessToken}

--- a/packages/widgets/src/components/index.jsx
+++ b/packages/widgets/src/components/index.jsx
@@ -71,6 +71,19 @@ class Quiz extends Component {
     this.setState({ quizAnswer: { ...quizAnswer, ...{ itemAnswers } } })
   }
 
+  handleIntOptionChange = (itemId) => (event) => {
+    //conversion to be sure
+    const value = Number(event.target.value)
+    const itemAnswers = this.state.quizAnswer.itemAnswers.map(itemAnswer => {
+      if(itemAnswer.quizItemId === itemId){
+        return { ...itemAnswer, intData: value}
+      }
+      return itemAnswer
+    })
+
+    this.setState({ quizAnswer: { ...this.state.quizAnswer, ...{ itemAnswers } } })
+  }
+
   handleSubmit = async (event) => {
     const response = await axios.post(
       `http://localhost:3000/api/v1/quizzes/answer`,
@@ -108,10 +121,12 @@ class Quiz extends Component {
               languageId={languageId}
               answered={this.state.quizAnswer.id ? true : false}
               textData={this.state.quizAnswer.itemAnswers.find(ia => ia.quizItemId === item.id).textData}
+              intData={this.state.quizAnswer.itemAnswers.find(ia => ia.quizItemId === item.id).intData}
               peerReviewsGiven={this.state.userQuizState ? this.state.userQuizState.peerReviewsGiven : 0}
               peerReviewQuestions={this.state.quiz.peerReviewQuestionCollections}
               submitMessage={this.state.quiz.texts[0].submitMessage}
               handleTextFieldChange={this.handleTextFieldChange(item.id)}
+              handleIntOptionChange={this.handleIntOptionChange(item.id)}
               setUserQuizState={this.setUserQuizState}
             />
           })}

--- a/packages/widgets/src/components/index.jsx
+++ b/packages/widgets/src/components/index.jsx
@@ -2,15 +2,23 @@ import React, { Component } from "react"
 import { Button, Typography } from "@material-ui/core"
 import Essay from "./Essay"
 import MultipleChoice from "./MultipleChoice"
+import Scale from './Scale'
 import axios from "axios"
 
 const mapTypeToComponent = {
   essay: Essay,
   "multiple-choice": MultipleChoice,
+  scale: Scale
 }
 
-const id = "4bf4cf2f-3058-4311-8d16-26d781261af7"
-const accessToken = "1436f0ed8869efc9d89ce0b6706d9ba07747490e2ed5b2ef3dd18caf0f0ac04a"
+const ids = {
+  scale_id: "2684de7b-f52a-4411-a96f-c4f996bc6f4f",
+  essay_id: "4901fd41-2e77-4c3f-a2d9-255582fca7b6",
+  multiple_choice_id: "4bf4cf2f-3058-4311-8d16-26d781261af7"
+}
+
+const id = ids.scale_id
+const accessToken = ""
 const languageId = "en_US"
 
 class Quiz extends Component {
@@ -93,6 +101,7 @@ class Quiz extends Component {
           {this.state.quiz.items.map(item => {
             const ItemComponent = mapTypeToComponent[item.type]
             return <ItemComponent
+              title={item.texts[0].title}
               quizId={id}
               key={item.id}
               accessToken={accessToken}

--- a/packages/widgets/src/components/index.jsx
+++ b/packages/widgets/src/components/index.jsx
@@ -179,6 +179,7 @@ class Quiz extends Component {
               accessToken={accessToken}
               languageId={languageId}
               answered={quizAnswer.id ? true : false}
+              intData={itemAnswer.intData}
               textData={itemAnswer.textData}
               optionAnswers={itemAnswer.optionAnswers}
               multi={item.multi}

--- a/packages/widgets/src/components/index.jsx
+++ b/packages/widgets/src/components/index.jsx
@@ -34,7 +34,6 @@ class Quiz extends Component {
       `http://localhost:3000/api/v1/quizzes/${id}?language=${languageId}`,
       { headers: { authorization: `Bearer ${accessToken}` } }
     )
-    console.log(response.data)
     const quiz = response.data.quiz
     let quizAnswer = response.data.quizAnswer
     if (!quizAnswer) {

--- a/packages/widgets/src/index.jsx
+++ b/packages/widgets/src/index.jsx
@@ -4,13 +4,6 @@ import HelloWorld from './components/'
 
 const root = document.getElementById('root')
 
-const ids = {
-  scale_id: "37263843-2319-4ef6-8c32-1c33a49e6c04",
-  essay_id: "4901fd41-2e77-4c3f-a2d9-255582fca7b6",
-  multiple_choice_id: "4bf4cf2f-3058-4311-8d16-26d781261af7"
-}
-
 render((
-  <HelloWorld id={ids.scale_id} accessToken={""}
-  languageId={"en_US"} />
+  <HelloWorld />
 ), root)


### PR DESCRIPTION
Widget for scale type quiz items. Other small changes: 

* Unsupported quiz item component (Null(/undefined) Object Pattern). An error message is shown in place of the quiz item instead of the page failing to load as was the case earlier
* Naming change: handleText*Field*Change and handleInt*Field*Change => handleText*Data*Change and handleInt*Data*Change