### PR TITLE
Improvements to dashboard items

### DIFF
--- a/packages/dashboard/src/components/Item.tsx
+++ b/packages/dashboard/src/components/Item.tsx
@@ -25,7 +25,7 @@ import {
   Toolbar,
   Typography,
 } from "@material-ui/core"
-import React, { ChangeEvent } from "react"
+import React, { ChangeEvent, createRef } from "react"
 import { connect } from "react-redux"
 import {
   arrayMove,
@@ -47,19 +47,28 @@ import DragHandleWrapper from "./DragHandleWrapper"
 import OptionContainer from "./OptionContainer"
 
 class Item extends React.Component<any, any> {
+  private myRef = createRef<HTMLInputElement>()
+
   constructor(props) {
     super(props)
     this.state = {
-      expanded: false,
+      expanded: props.newlyAdded,
     }
   }
 
   // DISSPLAYNG THE ESSAY: SHOULD BE MORE UNIFORM WITH THE OTHERS!
 
+  public componentDidMount() {
+    if (this.props.newlyAdded) {
+      this.props.scrollToNew(this.myRef.current)
+    }
+  }
+
   public shouldComponentUpdate(nextProps, nextState) {
     if (nextState.expanded !== this.state.expanded) {
       return true
     }
+
     const modificationFields: string[] = [
       "title",
       "body",
@@ -69,6 +78,7 @@ class Item extends React.Component<any, any> {
       "failureMessage",
       "validityRegex",
       "formatRegex",
+      "newlyAdded",
     ]
 
     return modificationFields.some(
@@ -77,16 +87,11 @@ class Item extends React.Component<any, any> {
   }
 
   public render() {
-    // console.log("item")
-
     const renderOptions = type => {
       return ["multiple-choice", "checkbox", "research-agreement"].includes(
         type,
       )
     }
-
-    console.log("Props: ", this.props)
-
     return (
       <Card style={{ marginBottom: 20 }}>
         <Grid style={{ flexGrow: 1 }} container={true} spacing={16}>
@@ -136,7 +141,11 @@ class Item extends React.Component<any, any> {
                     <Typography variant="subtitle1">
                       Type: {this.props.type}
                     </Typography>
+
                     <TextField
+                      inputProps={{
+                        ref: this.myRef,
+                      }}
                       label="title"
                       value={this.props.title || undefined}
                       fullWidth={true}
@@ -148,6 +157,7 @@ class Item extends React.Component<any, any> {
                       multiline={true}
                       margin="normal"
                     />
+
                     <TextField
                       label="body"
                       value={this.props.body || undefined}

--- a/packages/dashboard/src/components/Item.tsx
+++ b/packages/dashboard/src/components/Item.tsx
@@ -177,9 +177,9 @@ class Item extends React.Component<any, any> {
 
                     {this.props.type === "essay" && (
                       <Grid container={true} spacing={16}>
-                        <Grid item={true} xs={3}>
+                        <Grid item={true} xs={12}>
                           <TextField
-                            label="minimum number of words (optional)"
+                            label="min words (optional)"
                             value={this.props.minWords || undefined}
                             onChange={
                               executeIfOnlyDigitsInTextField(
@@ -197,9 +197,9 @@ class Item extends React.Component<any, any> {
                           />
                         </Grid>
 
-                        <Grid item={true} xs={3}>
+                        <Grid item={true} xs={12}>
                           <TextField
-                            label="maximum number of words (optional)"
+                            label="max words (optional)"
                             value={this.props.maxWords || undefined}
                             onChange={
                               executeIfOnlyDigitsInTextField(

--- a/packages/dashboard/src/components/Item.tsx
+++ b/packages/dashboard/src/components/Item.tsx
@@ -52,7 +52,7 @@ class Item extends React.Component<any, any> {
   constructor(props) {
     super(props)
     this.state = {
-      expanded: props.newlyAdded,
+      expanded: false,
     }
   }
 
@@ -61,6 +61,7 @@ class Item extends React.Component<any, any> {
   public componentDidMount() {
     if (this.props.newlyAdded) {
       this.props.scrollToNew(this.myRef.current)
+      this.setState({ expanded: true })
     }
   }
 

--- a/packages/dashboard/src/components/Item.tsx
+++ b/packages/dashboard/src/components/Item.tsx
@@ -89,40 +89,41 @@ class Item extends React.Component<any, any> {
 
     return (
       <Card style={{ marginBottom: 20 }}>
-        {!this.state.expanded ? (
-          <Grid style={{ flexGrow: 1 }} container={true} spacing={16}>
-            <Grid item={true} xs={11}>
-              <DragHandleWrapper>
-                <CardHeader
-                  title={
-                    this.props.title ||
-                    this.props.type[0].toUpperCase() + this.props.type.slice(1)
-                  }
-                  titleTypographyProps={{
-                    variant: "subtitle1",
-                    gutterBottom: false,
-                  }}
-                />
-              </DragHandleWrapper>
-            </Grid>
+        <Grid style={{ flexGrow: 1 }} container={true} spacing={16}>
+          <Grid item={true} xs={11}>
+            <DragHandleWrapper>
+              <CardHeader
+                title={
+                  this.props.title ||
+                  this.props.type[0].toUpperCase() + this.props.type.slice(1)
+                }
+                titleTypographyProps={{
+                  variant: "subtitle1",
+                  gutterBottom: false,
+                }}
+              />
+            </DragHandleWrapper>
+          </Grid>
 
-            <Grid item={true} xs={1}>
-              <Grid container={true} justify="flex-end">
-                <Grid item={true}>
-                  <CardActions>
-                    <IconButton onClick={this.handleExpand}>
-                      <SvgIcon>
-                        <path d="M12.44 6.44L9 9.88 5.56 6.44 4.5 7.5 9 12l4.5-4.5z" />
-                      </SvgIcon>
-                    </IconButton>
-                  </CardActions>
-                </Grid>
+          <Grid item={true} xs={1}>
+            <Grid container={true} justify="flex-end">
+              <Grid item={true}>
+                <CardActions>
+                  <IconButton
+                    onClick={this.toggleExpand}
+                    style={{
+                      transform: this.state.expanded ? "rotate(180deg)" : "",
+                    }}
+                  >
+                    <SvgIcon>
+                      <path d="M12.44 6.44L9 9.88 5.56 6.44 4.5 7.5 9 12l4.5-4.5z" />
+                    </SvgIcon>
+                  </IconButton>
+                </CardActions>
               </Grid>
             </Grid>
           </Grid>
-        ) : (
-          <p />
-        )}
+        </Grid>
 
         <Collapse in={this.state.expanded}>
           <CardContent>
@@ -293,22 +294,6 @@ class Item extends React.Component<any, any> {
               ) : (
                 <p />
               )}
-              <Grid item={true} xs={12}>
-                <Grid container={true} justify="flex-end">
-                  <Grid item={true}>
-                    <CardActions>
-                      <IconButton
-                        onClick={this.handleExpand}
-                        style={{ transform: "rotate(180deg)" }}
-                      >
-                        <SvgIcon>
-                          <path d="M12.44 6.44L9 9.88 5.56 6.44 4.5 7.5 9 12l4.5-4.5z" />
-                        </SvgIcon>
-                      </IconButton>
-                    </CardActions>
-                  </Grid>
-                </Grid>
-              </Grid>
             </Grid>
           </CardContent>
         </Collapse>
@@ -316,7 +301,7 @@ class Item extends React.Component<any, any> {
     )
   }
 
-  private handleExpand = event => {
+  private toggleExpand = event => {
     this.setState({ expanded: !this.state.expanded })
   }
 }

--- a/packages/dashboard/src/components/Item.tsx
+++ b/packages/dashboard/src/components/Item.tsx
@@ -111,14 +111,13 @@ class Item extends React.Component<any, any> {
             <Grid container={true} justify="flex-end">
               <Grid item={true}>
                 <CardActions>
-                  <IconButton
-                    onClick={this.toggleExpand}
-                    style={{
-                      transform: this.state.expanded ? "rotate(180deg)" : "",
-                    }}
-                  >
+                  <IconButton onClick={this.toggleExpand}>
                     <SvgIcon>
-                      <path d="M12.44 6.44L9 9.88 5.56 6.44 4.5 7.5 9 12l4.5-4.5z" />
+                      {this.state.expanded ? (
+                        <path d="M9 6l-4.5 4.5 1.06 1.06L9 8.12l3.44 3.44 1.06-1.06z" />
+                      ) : (
+                        <path d="M12.44 6.44L9 9.88 5.56 6.44 4.5 7.5 9 12l4.5-4.5z" />
+                      )}
                     </SvgIcon>
                   </IconButton>
                 </CardActions>

--- a/packages/dashboard/src/components/Item.tsx
+++ b/packages/dashboard/src/components/Item.tsx
@@ -62,6 +62,10 @@ class Item extends React.Component<any, any> {
     if (this.props.newlyAdded) {
       this.props.scrollToNew(this.myRef.current)
       this.setState({ expanded: true })
+      this.props.expanded(true, this.props.index)
+    }
+    if (this.props.expandedAtBeginning) {
+      this.setState({ expanded: true })
     }
   }
 
@@ -316,6 +320,7 @@ class Item extends React.Component<any, any> {
   }
 
   private toggleExpand = event => {
+    this.props.expanded(!this.state.expanded, this.props.order)
     this.setState({ expanded: !this.state.expanded })
   }
 }

--- a/packages/dashboard/src/components/Item.tsx
+++ b/packages/dashboard/src/components/Item.tsx
@@ -98,7 +98,12 @@ class Item extends React.Component<any, any> {
       )
     }
     return (
-      <Card style={{ marginBottom: 20 }}>
+      <Card
+        style={{
+          marginBottom: 20,
+          backgroundColor: this.state.expanded ? "#CCCCCC" : "inherit",
+        }}
+      >
         <Grid style={{ flexGrow: 1 }} container={true} spacing={16}>
           <Grid item={true} xs={11}>
             <DragHandleWrapper>

--- a/packages/dashboard/src/components/Item.tsx
+++ b/packages/dashboard/src/components/Item.tsx
@@ -115,9 +115,10 @@ class Item extends React.Component<any, any> {
                       this.props.type.slice(1)
                 }
                 titleTypographyProps={{
-                  variant: "subtitle1",
+                  variant: "title",
                   gutterBottom: false,
                 }}
+                
               />
             </DragHandleWrapper>
           </Grid>

--- a/packages/dashboard/src/components/Item.tsx
+++ b/packages/dashboard/src/components/Item.tsx
@@ -53,10 +53,23 @@ class Item extends React.Component<any, any> {
     super(props)
     this.state = {
       expanded: false,
+      expandedOptions: {},
+      optionSortInSession: false,
     }
   }
 
   // DISSPLAYNG THE ESSAY: SHOULD BE MORE UNIFORM WITH THE OTHERS!
+
+  public expandOption = (order: number) => {
+    if (this.state.optionSortInSession) {
+      return
+    }
+    const newExpList: boolean[] = { ...this.state.expandedOptions }
+    newExpList[order] = !newExpList[order]
+    this.setState({
+      expandedOptions: newExpList,
+    })
+  }
 
   public componentDidMount() {
     if (this.props.newlyAdded) {
@@ -73,6 +86,10 @@ class Item extends React.Component<any, any> {
     if (nextState.expanded !== this.state.expanded) {
       return true
     }
+    if (nextState.expandedOptions !== this.state.expandedOptions) {
+      return true
+    }
+
     const modificationFields: string[] = [
       "title",
       "body",
@@ -305,7 +322,10 @@ class Item extends React.Component<any, any> {
                     <CardContent>
                       <OptionContainer
                         axis="xy"
-                        onSortEnd={this.props.handleSort}
+                        expandedOptions={this.state.expandedOptions}
+                        expansionChange={this.expandOption}
+                        onSortEnd={this.onSortEnd}
+                        onSortStart={this.onSortStart}
                         index={this.props.index}
                         useDragHandle={true}
                         language={this.props.language}
@@ -329,6 +349,25 @@ class Item extends React.Component<any, any> {
     this.props.expanded(!this.state.expanded, this.props.order)
     this.setState({ expanded: !this.state.expanded })
   }
+
+  private onSortStart = ({ oldIndex, newIndex, collection }) => {
+    this.setState({ optionSortInSession: true })
+  }
+
+  private onSortEnd = ({ oldIndex, newIndex, collection }) => {
+    const newExpList = { ...this.state.expandedOptions }
+    const temp = newExpList[oldIndex]
+    newExpList[oldIndex] = newExpList[newIndex]
+    newExpList[newIndex] = temp
+    this.setState({
+      expandedOptions: newExpList,
+      optionSortInSession: false,
+    })
+    this.props.changeOrder(collection, oldIndex, newIndex)
+  }
 }
 
-export default connect()(Item)
+export default connect(
+  null,
+  { changeOrder },
+)(Item)

--- a/packages/dashboard/src/components/Item.tsx
+++ b/packages/dashboard/src/components/Item.tsx
@@ -62,7 +62,7 @@ class Item extends React.Component<any, any> {
     if (this.props.newlyAdded) {
       this.props.scrollToNew(this.myRef.current)
       this.setState({ expanded: true })
-      this.props.expanded(true, this.props.index)
+      this.props.expanded(true, this.props.order)
     }
     if (this.props.expandedAtBeginning) {
       this.setState({ expanded: true })
@@ -83,6 +83,7 @@ class Item extends React.Component<any, any> {
       "validityRegex",
       "formatRegex",
       "newlyAdded",
+      "expandedAtBeginning",
     ]
 
     return modificationFields.some(

--- a/packages/dashboard/src/components/Item.tsx
+++ b/packages/dashboard/src/components/Item.tsx
@@ -118,7 +118,6 @@ class Item extends React.Component<any, any> {
                   variant: "title",
                   gutterBottom: false,
                 }}
-                
               />
             </DragHandleWrapper>
           </Grid>

--- a/packages/dashboard/src/components/Item.tsx
+++ b/packages/dashboard/src/components/Item.tsx
@@ -47,23 +47,18 @@ import DragHandleWrapper from "./DragHandleWrapper"
 import OptionContainer from "./OptionContainer"
 
 class Item extends React.Component<any, any> {
-  private myRef = createRef<HTMLInputElement>()
+  private titleRef = createRef<HTMLInputElement>()
 
   constructor(props) {
     super(props)
     this.state = {
-      expanded: false,
       expandedOptions: {},
-      optionSortInSession: false,
     }
   }
 
   // DISSPLAYNG THE ESSAY: SHOULD BE MORE UNIFORM WITH THE OTHERS!
 
   public expandOption = (order: number) => {
-    if (this.state.optionSortInSession) {
-      return
-    }
     const newExpList: boolean[] = { ...this.state.expandedOptions }
     newExpList[order] = !newExpList[order]
     this.setState({
@@ -73,20 +68,16 @@ class Item extends React.Component<any, any> {
 
   public componentDidMount() {
     if (this.props.newlyAdded) {
-      this.props.scrollToNew(this.myRef.current)
-      this.setState({ expanded: true })
-      this.props.expanded(true, this.props.order)
-    }
-    if (this.props.expandedAtBeginning) {
-      this.setState({ expanded: true })
+      this.props.scrollToNew(this.titleRef.current)
+      this.props.expandItem(this.props.order)
     }
   }
 
   public shouldComponentUpdate(nextProps, nextState) {
-    if (nextState.expanded !== this.state.expanded) {
+    if (nextState.expandedOptions !== this.state.expandedOptions) {
       return true
     }
-    if (nextState.expandedOptions !== this.state.expandedOptions) {
+    if (nextProps.expanded !== this.props.expanded) {
       return true
     }
 
@@ -100,7 +91,7 @@ class Item extends React.Component<any, any> {
       "validityRegex",
       "formatRegex",
       "newlyAdded",
-      "expandedAtBeginning",
+      "expanded",
     ]
 
     return modificationFields.some(
@@ -118,7 +109,7 @@ class Item extends React.Component<any, any> {
       <Card
         style={{
           marginBottom: 20,
-          backgroundColor: this.state.expanded ? "#CCCCCC" : "inherit",
+          backgroundColor: this.props.expanded ? "#DDDDDD" : "inherit",
         }}
       >
         <Grid style={{ flexGrow: 1 }} container={true} spacing={16}>
@@ -145,7 +136,7 @@ class Item extends React.Component<any, any> {
                 <CardActions>
                   <IconButton onClick={this.toggleExpand}>
                     <SvgIcon>
-                      {this.state.expanded ? (
+                      {this.props.expanded ? (
                         <path d="M9 6l-4.5 4.5 1.06 1.06L9 8.12l3.44 3.44 1.06-1.06z" />
                       ) : (
                         <path d="M12.44 6.44L9 9.88 5.56 6.44 4.5 7.5 9 12l4.5-4.5z" />
@@ -158,7 +149,7 @@ class Item extends React.Component<any, any> {
           </Grid>
         </Grid>
 
-        <Collapse in={this.state.expanded}>
+        <Collapse in={this.props.expanded}>
           <CardContent>
             <Grid style={{ flexGrow: 1 }} container={true} spacing={16}>
               <Grid item={true} xs={12}>
@@ -171,7 +162,7 @@ class Item extends React.Component<any, any> {
 
                     <TextField
                       inputProps={{
-                        ref: this.myRef,
+                        ref: this.titleRef,
                       }}
                       label="title"
                       value={this.props.title || undefined}
@@ -324,8 +315,7 @@ class Item extends React.Component<any, any> {
                         axis="xy"
                         expandedOptions={this.state.expandedOptions}
                         expansionChange={this.expandOption}
-                        onSortEnd={this.onSortEnd}
-                        onSortStart={this.onSortStart}
+                        onSortEnd={this.onOptionSortEnd}
                         index={this.props.index}
                         useDragHandle={true}
                         language={this.props.language}
@@ -346,22 +336,17 @@ class Item extends React.Component<any, any> {
   }
 
   private toggleExpand = event => {
-    this.props.expanded(!this.state.expanded, this.props.order)
-    this.setState({ expanded: !this.state.expanded })
+    console.log("exPAND")
+    this.props.expandItem(this.props.order)
   }
 
-  private onSortStart = ({ oldIndex, newIndex, collection }) => {
-    this.setState({ optionSortInSession: true })
-  }
-
-  private onSortEnd = ({ oldIndex, newIndex, collection }) => {
+  private onOptionSortEnd = ({ oldIndex, newIndex, collection }) => {
     const newExpList = { ...this.state.expandedOptions }
     const temp = newExpList[oldIndex]
     newExpList[oldIndex] = newExpList[newIndex]
     newExpList[newIndex] = temp
     this.setState({
       expandedOptions: newExpList,
-      optionSortInSession: false,
     })
     this.props.changeOrder(collection, oldIndex, newIndex)
   }

--- a/packages/dashboard/src/components/Item.tsx
+++ b/packages/dashboard/src/components/Item.tsx
@@ -68,7 +68,6 @@ class Item extends React.Component<any, any> {
     if (nextState.expanded !== this.state.expanded) {
       return true
     }
-
     const modificationFields: string[] = [
       "title",
       "body",

--- a/packages/dashboard/src/components/Item.tsx
+++ b/packages/dashboard/src/components/Item.tsx
@@ -94,8 +94,10 @@ class Item extends React.Component<any, any> {
             <DragHandleWrapper>
               <CardHeader
                 title={
-                  this.props.title ||
-                  this.props.type[0].toUpperCase() + this.props.type.slice(1)
+                  this.props.title
+                    ? this.props.title + " (" + this.props.type + ")"
+                    : this.props.type[0].toUpperCase() +
+                      this.props.type.slice(1)
                 }
                 titleTypographyProps={{
                   variant: "subtitle1",
@@ -132,6 +134,9 @@ class Item extends React.Component<any, any> {
                 <Card>
                   <CardHeader subheader="general" />
                   <CardContent>
+                    <Typography variant="subtitle1">
+                      Type: {this.props.type}
+                    </Typography>
                     <TextField
                       label="title"
                       value={this.props.title || undefined}

--- a/packages/dashboard/src/components/Item.tsx
+++ b/packages/dashboard/src/components/Item.tsx
@@ -336,7 +336,6 @@ class Item extends React.Component<any, any> {
   }
 
   private toggleExpand = event => {
-    console.log("exPAND")
     this.props.expandItem(this.props.order)
   }
 

--- a/packages/dashboard/src/components/ItemContainer.tsx
+++ b/packages/dashboard/src/components/ItemContainer.tsx
@@ -48,26 +48,19 @@ import SortableWrapper from "./SortableWrapper"
 
 const ItemContainer: ComponentClass<any, any> = SortableContainer(
   (props: any) => {
-    const newest = props.items
-      .sort((i1, i2) => i2.order - i1.order)
-      .find(i => !i.id)
-
     return (
       <div>
         {props.items.map((item, index) => {
           const text = item.texts.find(t => t.languageId === props.language)
           return (
-            // <SortableWrapper
-            //  key={item.id || item.type + index}
-            //   index={index}
-            //     collection="items"
-            //    >
+            /*       <SortableWrapper
+              key={item.id || item.type + index}
+               index={index}
+                 collection="items"
+                > */
             <Item
               key={item.id || item.type + index}
-              inputProps={{
-                ref: props.myRef,
-              }}
-              newlyAdded={item === newest}
+              newlyAdded={props.newest && item.order === props.newest.order}
               language={props.language}
               handleChange={props.handleChange}
               index={index}
@@ -89,7 +82,7 @@ const ItemContainer: ComponentClass<any, any> = SortableContainer(
               maxWords={item.maxWords}
               scrollToNew={props.scrollToNew}
             />
-            //        </SortableWrapper>
+            //         </SortableWrapper>
           )
         })}
       </div>

--- a/packages/dashboard/src/components/ItemContainer.tsx
+++ b/packages/dashboard/src/components/ItemContainer.tsx
@@ -48,43 +48,48 @@ import SortableWrapper from "./SortableWrapper"
 
 const ItemContainer: ComponentClass<any, any> = SortableContainer(
   (props: any) => {
-    console.log("Props for all items: ", props)
     const newest = props.items
-      .sort((i1, i2) => i1.order - i2.order)
+      .sort((i1, i2) => i2.order - i1.order)
       .find(i => !i.id)
+
     return (
       <div>
         {props.items.map((item, index) => {
           const text = item.texts.find(t => t.languageId === props.language)
           return (
-            <SortableWrapper
+            // <SortableWrapper
+            //  key={item.id || item.type + index}
+            //   index={index}
+            //     collection="items"
+            //    >
+            <Item
               key={item.id || item.type + index}
+              inputProps={{
+                ref: props.myRef,
+              }}
+              newlyAdded={item === newest}
+              language={props.language}
+              handleChange={props.handleChange}
               index={index}
-              collection="items"
-            >
-              <Item
-                newlyAdded={item === newest}
-                language={props.language}
-                handleChange={props.handleChange}
-                index={index}
-                handleSort={props.handleSort}
-                textIndex={item.texts.findIndex(
-                  t => t.languageId === props.language,
-                )}
-                order={item.order}
-                validityRegex={item.validityRegex}
-                formatRegex={item.formatRegex}
-                options={item.options}
-                title={text.title}
-                body={text.body}
-                successMessage={text.successMessage}
-                failureMessage={text.failureMessage}
-                type={item.type}
-                remove={props.remove}
-                minWords={item.minWords}
-                maxWords={item.maxWords}
-              />
-            </SortableWrapper>
+              handleSort={props.handleSort}
+              textIndex={item.texts.findIndex(
+                t => t.languageId === props.language,
+              )}
+              order={item.order}
+              validityRegex={item.validityRegex}
+              formatRegex={item.formatRegex}
+              options={item.options}
+              title={text.title}
+              body={text.body}
+              successMessage={text.successMessage}
+              failureMessage={text.failureMessage}
+              type={item.type}
+              remove={props.remove}
+              minWords={item.minWords}
+              maxWords={item.maxWords}
+              scrollToNew={props.scrollToNew}
+            />
+            //        </SortableWrapper>
           )
         })}
       </div>

--- a/packages/dashboard/src/components/ItemContainer.tsx
+++ b/packages/dashboard/src/components/ItemContainer.tsx
@@ -80,6 +80,11 @@ const ItemContainer: ComponentClass<any, any> = SortableContainer(
                 minWords={item.minWords}
                 maxWords={item.maxWords}
                 scrollToNew={props.scrollToNew}
+                expanded={props.expanded}
+                expandedAtBeginning={
+                  props.shouldBeExpandedList &&
+                  props.shouldBeExpandedList[index]
+                }
               />
             </SortableWrapper>
           )

--- a/packages/dashboard/src/components/ItemContainer.tsx
+++ b/packages/dashboard/src/components/ItemContainer.tsx
@@ -59,6 +59,7 @@ const ItemContainer: ComponentClass<any, any> = SortableContainer(
               collection="items"
             >
               <Item
+                // newlyAdded={props.preExistingItemIds.filter(x => x.id === item.id)}
                 language={props.language}
                 handleChange={props.handleChange}
                 index={index}

--- a/packages/dashboard/src/components/ItemContainer.tsx
+++ b/packages/dashboard/src/components/ItemContainer.tsx
@@ -48,6 +48,10 @@ import SortableWrapper from "./SortableWrapper"
 
 const ItemContainer: ComponentClass<any, any> = SortableContainer(
   (props: any) => {
+    console.log("Props for all items: ", props)
+    const newest = props.items
+      .sort((i1, i2) => i1.order - i2.order)
+      .find(i => !i.id)
     return (
       <div>
         {props.items.map((item, index) => {
@@ -59,7 +63,7 @@ const ItemContainer: ComponentClass<any, any> = SortableContainer(
               collection="items"
             >
               <Item
-                // newlyAdded={props.preExistingItemIds.filter(x => x.id === item.id)}
+                newlyAdded={item === newest}
                 language={props.language}
                 handleChange={props.handleChange}
                 index={index}

--- a/packages/dashboard/src/components/ItemContainer.tsx
+++ b/packages/dashboard/src/components/ItemContainer.tsx
@@ -81,10 +81,7 @@ const ItemContainer: ComponentClass<any, any> = SortableContainer(
                 maxWords={item.maxWords}
                 scrollToNew={props.scrollToNew}
                 expanded={props.expanded}
-                expandedAtBeginning={
-                  props.shouldBeExpandedList &&
-                  props.shouldBeExpandedList[index]
-                }
+                expandedAtBeginning={props.shouldBeExpandedList[item.order]}
               />
             </SortableWrapper>
           )

--- a/packages/dashboard/src/components/ItemContainer.tsx
+++ b/packages/dashboard/src/components/ItemContainer.tsx
@@ -63,10 +63,10 @@ const ItemContainer: ComponentClass<any, any> = SortableContainer(
                 language={props.language}
                 handleChange={props.handleChange}
                 index={index}
-                handleSort={props.handleSort}
                 textIndex={item.texts.findIndex(
                   t => t.languageId === props.language,
                 )}
+                onSortEnd={props.onSortEnd}
                 order={item.order}
                 validityRegex={item.validityRegex}
                 formatRegex={item.formatRegex}
@@ -80,8 +80,8 @@ const ItemContainer: ComponentClass<any, any> = SortableContainer(
                 minWords={item.minWords}
                 maxWords={item.maxWords}
                 scrollToNew={props.scrollToNew}
-                expanded={props.expanded}
-                expandedAtBeginning={props.shouldBeExpandedList[item.order]}
+                expandItem={props.expandItem}
+                expanded={props.expandedItems[item.order]}
               />
             </SortableWrapper>
           )

--- a/packages/dashboard/src/components/ItemContainer.tsx
+++ b/packages/dashboard/src/components/ItemContainer.tsx
@@ -53,36 +53,35 @@ const ItemContainer: ComponentClass<any, any> = SortableContainer(
         {props.items.map((item, index) => {
           const text = item.texts.find(t => t.languageId === props.language)
           return (
-            /*       <SortableWrapper
+            <SortableWrapper
               key={item.id || item.type + index}
-               index={index}
-                 collection="items"
-                > */
-            <Item
-              key={item.id || item.type + index}
-              newlyAdded={props.newest && item.order === props.newest.order}
-              language={props.language}
-              handleChange={props.handleChange}
               index={index}
-              handleSort={props.handleSort}
-              textIndex={item.texts.findIndex(
-                t => t.languageId === props.language,
-              )}
-              order={item.order}
-              validityRegex={item.validityRegex}
-              formatRegex={item.formatRegex}
-              options={item.options}
-              title={text.title}
-              body={text.body}
-              successMessage={text.successMessage}
-              failureMessage={text.failureMessage}
-              type={item.type}
-              remove={props.remove}
-              minWords={item.minWords}
-              maxWords={item.maxWords}
-              scrollToNew={props.scrollToNew}
-            />
-            //         </SortableWrapper>
+              collection="items"
+            >
+              <Item
+                newlyAdded={props.newest && item.order === props.newest.order}
+                language={props.language}
+                handleChange={props.handleChange}
+                index={index}
+                handleSort={props.handleSort}
+                textIndex={item.texts.findIndex(
+                  t => t.languageId === props.language,
+                )}
+                order={item.order}
+                validityRegex={item.validityRegex}
+                formatRegex={item.formatRegex}
+                options={item.options}
+                title={text.title}
+                body={text.body}
+                successMessage={text.successMessage}
+                failureMessage={text.failureMessage}
+                type={item.type}
+                remove={props.remove}
+                minWords={item.minWords}
+                maxWords={item.maxWords}
+                scrollToNew={props.scrollToNew}
+              />
+            </SortableWrapper>
           )
         })}
       </div>

--- a/packages/dashboard/src/components/Option.tsx
+++ b/packages/dashboard/src/components/Option.tsx
@@ -25,7 +25,7 @@ import {
   Toolbar,
   Typography,
 } from "@material-ui/core"
-import React from "react"
+import React, { createRef } from "react"
 import { connect } from "react-redux"
 import {
   arrayMove,
@@ -56,29 +56,20 @@ class Option extends React.Component<any, any> {
 
   constructor(props) {
     super(props)
-    this.state = {
-      expanded: false,
-    }
   }
 
   public shouldComponentUpdate(nextProps, nextState) {
-    if (nextState.expanded !== this.state.expanded) {
-      return true
-    }
-
     return Option.attributes.some(
       attribute => nextProps[attribute] === this.props[attribute],
     )
   }
 
   public render() {
-    // console.log("option")
-
     return (
       <SortableGridItem
         index={this.props.index}
         collection={this.props.collection}
-        size={!this.state.expanded ? 12 : 12}
+        size={12}
       >
         <Card>
           <Grid style={{ flexGrow: 1 }} container={true} spacing={16}>
@@ -99,7 +90,7 @@ class Option extends React.Component<any, any> {
                   <CardActions>
                     <IconButton onClick={this.toggleExpand}>
                       <SvgIcon>
-                        {this.state.expanded ? (
+                        {this.props.expanded ? (
                           <path d="M9 6l-4.5 4.5 1.06 1.06L9 8.12l3.44 3.44 1.06-1.06z" />
                         ) : (
                           <path d="M12.44 6.44L9 9.88 5.56 6.44 4.5 7.5 9 12l4.5-4.5z" />
@@ -112,7 +103,7 @@ class Option extends React.Component<any, any> {
             </Grid>
           </Grid>
 
-          {this.state.expanded && (
+          {this.props.expanded && (
             <CardContent>
               <Card>
                 <CardHeader subheader="general" />
@@ -213,7 +204,7 @@ class Option extends React.Component<any, any> {
   }
 
   private toggleExpand = event => {
-    this.setState({ expanded: !this.state.expanded })
+    this.props.expansionChange(this.props.index)
   }
 }
 

--- a/packages/dashboard/src/components/Option.tsx
+++ b/packages/dashboard/src/components/Option.tsx
@@ -81,8 +81,8 @@ class Option extends React.Component<any, any> {
         size={!this.state.expanded ? 12 : 12}
       >
         <Card>
-          {!this.state.expanded ? (
-            <Grid style={{ flexGrow: 1 }} container={true} spacing={16}>
+
+        <Grid style={{ flexGrow: 1 }} container={true} spacing={16}>
               <Grid item={true} xs={11}>
                 <DragHandleWrapper>
                   <CardHeader
@@ -98,17 +98,22 @@ class Option extends React.Component<any, any> {
                 <Grid container={true} justify="flex-end">
                   <Grid item={true}>
                     <CardActions>
-                      <IconButton onClick={this.handleExpand}>
-                        <SvgIcon>
-                          <path d="M12.44 6.44L9 9.88 5.56 6.44 4.5 7.5 9 12l4.5-4.5z" />
-                        </SvgIcon>
-                      </IconButton>
+                    <IconButton onClick={this.toggleExpand}>
+                    <SvgIcon>
+                      {this.state.expanded ? (
+                        <path d="M9 6l-4.5 4.5 1.06 1.06L9 8.12l3.44 3.44 1.06-1.06z" />
+                      ) : (
+                        <path d="M12.44 6.44L9 9.88 5.56 6.44 4.5 7.5 9 12l4.5-4.5z" />
+                      )}
+                    </SvgIcon>
+                  </IconButton>
                     </CardActions>
                   </Grid>
                 </Grid>
               </Grid>
             </Grid>
-          ) : (
+
+          {this.state.expanded &&  (
             <CardContent>
               <Card>
                 <CardHeader subheader="general" />
@@ -198,22 +203,6 @@ class Option extends React.Component<any, any> {
                         </Grid>
                       </Grid>
                     </Grid>
-                    <Grid item={true} xs={12}>
-                      <Grid container={true} justify="flex-end">
-                        <Grid item={true}>
-                          <CardActions>
-                            <IconButton
-                              onClick={this.handleExpand}
-                              style={{ transform: "rotate(180deg)" }}
-                            >
-                              <SvgIcon>
-                                <path d="M12.44 6.44L9 9.88 5.56 6.44 4.5 7.5 9 12l4.5-4.5z" />
-                              </SvgIcon>
-                            </IconButton>
-                          </CardActions>
-                        </Grid>
-                      </Grid>
-                    </Grid>
                   </Grid>
                 </CardContent>
               </Card>
@@ -224,7 +213,7 @@ class Option extends React.Component<any, any> {
     )
   }
 
-  private handleExpand = event => {
+  private toggleExpand = event => {
     this.setState({ expanded: !this.state.expanded })
   }
 }

--- a/packages/dashboard/src/components/Option.tsx
+++ b/packages/dashboard/src/components/Option.tsx
@@ -81,39 +81,38 @@ class Option extends React.Component<any, any> {
         size={!this.state.expanded ? 12 : 12}
       >
         <Card>
-
-        <Grid style={{ flexGrow: 1 }} container={true} spacing={16}>
-              <Grid item={true} xs={11}>
-                <DragHandleWrapper>
-                  <CardHeader
-                    title={this.props.title}
-                    titleTypographyProps={{
-                      variant: "subtitle1",
-                      gutterBottom: false,
-                    }}
-                  />
-                </DragHandleWrapper>
-              </Grid>
-              <Grid item={true} xs={1}>
-                <Grid container={true} justify="flex-end">
-                  <Grid item={true}>
-                    <CardActions>
+          <Grid style={{ flexGrow: 1 }} container={true} spacing={16}>
+            <Grid item={true} xs={11}>
+              <DragHandleWrapper>
+                <CardHeader
+                  title={this.props.title}
+                  titleTypographyProps={{
+                    variant: "subtitle1",
+                    gutterBottom: false,
+                  }}
+                />
+              </DragHandleWrapper>
+            </Grid>
+            <Grid item={true} xs={1}>
+              <Grid container={true} justify="flex-end">
+                <Grid item={true}>
+                  <CardActions>
                     <IconButton onClick={this.toggleExpand}>
-                    <SvgIcon>
-                      {this.state.expanded ? (
-                        <path d="M9 6l-4.5 4.5 1.06 1.06L9 8.12l3.44 3.44 1.06-1.06z" />
-                      ) : (
-                        <path d="M12.44 6.44L9 9.88 5.56 6.44 4.5 7.5 9 12l4.5-4.5z" />
-                      )}
-                    </SvgIcon>
-                  </IconButton>
-                    </CardActions>
-                  </Grid>
+                      <SvgIcon>
+                        {this.state.expanded ? (
+                          <path d="M9 6l-4.5 4.5 1.06 1.06L9 8.12l3.44 3.44 1.06-1.06z" />
+                        ) : (
+                          <path d="M12.44 6.44L9 9.88 5.56 6.44 4.5 7.5 9 12l4.5-4.5z" />
+                        )}
+                      </SvgIcon>
+                    </IconButton>
+                  </CardActions>
                 </Grid>
               </Grid>
             </Grid>
+          </Grid>
 
-          {this.state.expanded &&  (
+          {this.state.expanded && (
             <CardContent>
               <Card>
                 <CardHeader subheader="general" />

--- a/packages/dashboard/src/components/Option.tsx
+++ b/packages/dashboard/src/components/Option.tsx
@@ -45,6 +45,15 @@ import {
 import DragHandleWrapper from "./DragHandleWrapper"
 
 class Option extends React.Component<any, any> {
+  private static attributes: string[] = [
+    "index",
+    "correct",
+    "title",
+    "body",
+    "successMessage",
+    "failureMessage",
+  ]
+
   constructor(props) {
     super(props)
     this.state = {
@@ -56,25 +65,10 @@ class Option extends React.Component<any, any> {
     if (nextState.expanded !== this.state.expanded) {
       return true
     }
-    if (nextProps.index !== this.props.index) {
-      return true
-    }
-    if (nextProps.correct !== this.props.correct) {
-      return true
-    }
-    if (nextProps.title !== this.props.title) {
-      return true
-    }
-    if (nextProps.body !== this.props.body) {
-      return true
-    }
-    if (nextProps.successMessage !== this.props.successMessage) {
-      return true
-    }
-    if (nextProps.failureMessage !== this.props.failureMessage) {
-      return true
-    }
-    return false
+
+    return Option.attributes.some(
+      attribute => nextProps[attribute] === this.props[attribute],
+    )
   }
 
   public render() {

--- a/packages/dashboard/src/components/OptionContainer.tsx
+++ b/packages/dashboard/src/components/OptionContainer.tsx
@@ -50,7 +50,6 @@ const OptionContainer = SortableContainer((props: any) => {
   }
 
   const options = props.edit.items[props.index].options
-
   return (
     <Grid container={true} spacing={16}>
       {options
@@ -73,6 +72,8 @@ const OptionContainer = SortableContainer((props: any) => {
               successMessage={text.successMessage}
               failureMessage={text.failureMessage}
               remove={props.remove}
+              expanded={props.expandedOptions[index]}
+              expansionChange={props.expansionChange}
             />
           )
         })}

--- a/packages/dashboard/src/components/QuizForm.tsx
+++ b/packages/dashboard/src/components/QuizForm.tsx
@@ -132,10 +132,15 @@ class QuizForm extends React.Component<any, any> {
         )}
         <Toolbar>
           <Typography style={{ flex: 1 }} />
-          <Button onClick={this.props.save}>save</Button>
+          <Button onClick={this.handleSaving}>save</Button>
         </Toolbar>
       </div>
     )
+  }
+
+  private handleSaving = (event: any) => {
+    scrollTo(0, 0)
+    this.props.save(event)
   }
 
   private handleChange = path => event => {

--- a/packages/dashboard/src/components/TabContainer.tsx
+++ b/packages/dashboard/src/components/TabContainer.tsx
@@ -33,7 +33,7 @@ class TabContainer extends Component<any, any> {
       menuAnchor: null,
       scrollTo: null,
       justAdded: false,
-      expandList: [],
+      expandedItems: {},
     }
   }
 
@@ -57,7 +57,11 @@ class TabContainer extends Component<any, any> {
     if (this.state.scrollTo) {
       return true
     }
-    if (this.state.expandList.toString() === nextState.expandList.toString()) {
+
+    if (
+      JSON.stringify(this.state.expandedItems) !==
+      JSON.stringify(nextState.expandedItems)
+    ) {
       return true
     }
 
@@ -77,20 +81,17 @@ class TabContainer extends Component<any, any> {
     }
     const copy = JSON.parse(JSON.stringify(this.props.items))
     copy.sort((i1, i2) => i2.order - i1.order)
-    this.setState({ justAdded: false })
+    // this.setState({ justAdded: false })
     return copy.find(i => !i.id)
   }
 
-  public expanded = (isExpanded: boolean, index: number) => {
-    if (this.state.expandList.length === 0) {
-      const newList: boolean[] = []
-      newList[index] = isExpanded
-      this.setState({ expandList: newList })
-    } else {
-      const newList: boolean[] = { ...this.state.expandList }
-      newList[index] = isExpanded
-      this.setState({ expandList: newList })
+  public expandItem = (index: number) => {
+    if (typeof index !== "number") {
+      return
     }
+    const newExp = { ...this.state.expandedItems }
+    newExp[index] = newExp[index] ? !newExp[index] : true
+    this.setState({ expandedItems: newExp })
   }
 
   public render() {
@@ -140,7 +141,7 @@ class TabContainer extends Component<any, any> {
               Items / Question types:
             </Typography>
             <ItemContainer
-              expanded={this.expanded}
+              expandItem={this.expandItem}
               newest={this.newest()}
               onSortEnd={this.onSortEnd}
               items={this.props.items}
@@ -149,7 +150,7 @@ class TabContainer extends Component<any, any> {
               handleSort={this.onSortEnd}
               remove={this.remove}
               scrollToNew={this.scrollToNewItem}
-              shouldBeExpandedList={this.state.expandList}
+              expandedItems={this.state.expandedItems}
             />
 
             <Button id="item" onClick={this.handleMenu}>
@@ -218,11 +219,14 @@ class TabContainer extends Component<any, any> {
   }
 
   private onSortEnd = ({ oldIndex, newIndex, collection }) => {
-    const newList: boolean[] = { ...this.state.expandList }
-    const temp: boolean = newList[newIndex]
-    newList[newIndex] = newList[oldIndex]
-    newList[oldIndex] = temp
-    this.setState({ expandList: newList })
+    if (collection === "items") {
+      const newExp = { ...this.state.expandedItems }
+      const temp: boolean = newExp[oldIndex]
+      newExp[oldIndex] = newExp[newIndex]
+      newExp[newIndex] = temp
+      this.setState({ expandedItems: newExp })
+    }
+
     this.props.changeOrder(collection, oldIndex, newIndex)
   }
 }

--- a/packages/dashboard/src/components/TabContainer.tsx
+++ b/packages/dashboard/src/components/TabContainer.tsx
@@ -48,7 +48,6 @@ class TabContainer extends Component<any, any> {
 
   public componentDidUpdate() {
     if (this.state.scrollTo) {
-      this.state.scrollTo.focus()
       this.state.scrollTo.select()
       this.setState({ scrollTo: null })
     }
@@ -137,7 +136,7 @@ class TabContainer extends Component<any, any> {
         </div>
         <div style={{ marginTop: 50 }}>
           <Paper style={{ padding: 30, marginBottom: 20 }}>
-            <Typography variant="subtitle1" style={{ marginBottom: 10 }}>
+            <Typography variant="title" style={{ marginBottom: 10 }}>
               Items / Question types:
             </Typography>
             <ItemContainer
@@ -170,7 +169,7 @@ class TabContainer extends Component<any, any> {
           </Paper>
           {this.props.items.find(item => item.type === "essay") ? (
             <Paper style={{ padding: 30 }}>
-              <Typography variant="subtitle1" style={{ marginBottom: 10 }}>
+              <Typography variant="title" style={{ marginBottom: 10 }}>
                 Peer reviews:
               </Typography>
               <PeerReviewCollectionContainer

--- a/packages/dashboard/src/components/TabContainer.tsx
+++ b/packages/dashboard/src/components/TabContainer.tsx
@@ -87,7 +87,7 @@ class TabContainer extends Component<any, any> {
       newList[index] = isExpanded
       this.setState({ expandList: newList })
     } else {
-      const newList: boolean[] = this.state.expandList
+      const newList: boolean[] = { ...this.state.expandList }
       newList[index] = isExpanded
       this.setState({ expandList: newList })
     }

--- a/packages/dashboard/src/components/TabContainer.tsx
+++ b/packages/dashboard/src/components/TabContainer.tsx
@@ -6,15 +6,14 @@ import {
   TextField,
   Typography,
 } from "@material-ui/core"
-import React from "react"
+import { InputProps } from "@material-ui/core/Input"
+import React, { Component, createRef } from "react"
 import { connect } from "react-redux"
 import { addItem, addReview, changeOrder, remove } from "../store/edit/actions"
 import ItemContainer from "./ItemContainer"
 import PeerReviewCollectionContainer from "./PeerReviewCollectionContainer"
 
-class TabContainer extends React.Component<any, any> {
-  private itemCount
-
+class TabContainer extends Component<any, any> {
   private itemTypes = [
     "checkbox",
     "essay",
@@ -33,7 +32,45 @@ class TabContainer extends React.Component<any, any> {
       menuOpen: false,
       menuAnchor: null,
       preExisting: null,
+      scrollTo: null,
     }
+  }
+
+  public scrollToNewItem = (itemComponent: HTMLInputElement) => {
+    if (itemComponent) {
+      this.setState({
+        scrollTo: itemComponent,
+      })
+    }
+  }
+
+  public componentDidUpdate() {
+    if (this.state.scrollTo) {
+      this.state.scrollTo.focus()
+      this.state.scrollTo.select()
+      this.setState({
+        scrollTo: null,
+      })
+    }
+  }
+
+  public shouldComponentUpdate(nextProps, nextState) {
+    if (this.state.preExisting) {
+      return true
+    }
+
+    if (this.state.scrollTo) {
+      return true
+    }
+
+    if (
+      this.state.menuOpen !== nextState.menuOpen ||
+      (this.state.menuAnchor && nextState.menuAnchor)
+    ) {
+      return true
+    }
+
+    return this.props !== nextProps
   }
 
   public render() {
@@ -89,8 +126,9 @@ class TabContainer extends React.Component<any, any> {
               useDragHandle={true}
               handleSort={this.onSortEnd}
               remove={this.remove}
-              preExisting={this.state.preExisting}
+              scrollToNew={this.scrollToNewItem}
             />
+
             <Button id="item" onClick={this.handleMenu}>
               Add item
             </Button>
@@ -131,11 +169,12 @@ class TabContainer extends React.Component<any, any> {
   }
 
   private addItem = type => event => {
-    console.log(this.props.storeItems)
-    this.itemCount = this.props.storeItems.count
+    const existingAtStart = this.state.existing
+
     this.setState({
       preExisting: this.props.storeItems.map(qi => qi.id),
     })
+
     this.setState({
       menuOpen: null,
     })

--- a/packages/dashboard/src/components/TabContainer.tsx
+++ b/packages/dashboard/src/components/TabContainer.tsx
@@ -32,7 +32,7 @@ class TabContainer extends React.Component<any, any> {
     this.state = {
       menuOpen: false,
       menuAnchor: null,
-      preExistingQuizIds: null,
+      preExisting: null,
     }
   }
 
@@ -89,7 +89,7 @@ class TabContainer extends React.Component<any, any> {
               useDragHandle={true}
               handleSort={this.onSortEnd}
               remove={this.remove}
-              preExistingItemIds={this.state.preExistingItemIds}
+              preExisting={this.state.preExisting}
             />
             <Button id="item" onClick={this.handleMenu}>
               Add item
@@ -134,7 +134,7 @@ class TabContainer extends React.Component<any, any> {
     console.log(this.props.storeItems)
     this.itemCount = this.props.storeItems.count
     this.setState({
-      preExistingQuizIds: this.props.storeItems.map(qi => qi.id),
+      preExisting: this.props.storeItems.map(qi => qi.id),
     })
     this.setState({
       menuOpen: null,

--- a/packages/dashboard/src/components/TabContainer.tsx
+++ b/packages/dashboard/src/components/TabContainer.tsx
@@ -13,6 +13,8 @@ import ItemContainer from "./ItemContainer"
 import PeerReviewCollectionContainer from "./PeerReviewCollectionContainer"
 
 class TabContainer extends React.Component<any, any> {
+  private itemCount
+
   private itemTypes = [
     "checkbox",
     "essay",
@@ -30,6 +32,7 @@ class TabContainer extends React.Component<any, any> {
     this.state = {
       menuOpen: false,
       menuAnchor: null,
+      preExistingQuizIds: null,
     }
   }
 
@@ -86,6 +89,7 @@ class TabContainer extends React.Component<any, any> {
               useDragHandle={true}
               handleSort={this.onSortEnd}
               remove={this.remove}
+              preExistingItemIds={this.state.preExistingItemIds}
             />
             <Button id="item" onClick={this.handleMenu}>
               Add item
@@ -127,6 +131,11 @@ class TabContainer extends React.Component<any, any> {
   }
 
   private addItem = type => event => {
+    console.log(this.props.storeItems)
+    this.itemCount = this.props.storeItems.count
+    this.setState({
+      preExistingQuizIds: this.props.storeItems.map(qi => qi.id),
+    })
     this.setState({
       menuOpen: null,
     })
@@ -156,6 +165,12 @@ class TabContainer extends React.Component<any, any> {
   }
 }
 
+const mapStateToProps = (state: any) => {
+  return {
+    storeItems: state.edit.items,
+  }
+}
+
 const mapDispatchToProps = {
   addItem,
   addReview,
@@ -164,6 +179,6 @@ const mapDispatchToProps = {
 }
 
 export default connect(
-  null,
+  mapStateToProps,
   mapDispatchToProps,
 )(TabContainer)

--- a/packages/dashboard/src/components/TabContainer.tsx
+++ b/packages/dashboard/src/components/TabContainer.tsx
@@ -33,6 +33,7 @@ class TabContainer extends Component<any, any> {
       menuAnchor: null,
       scrollTo: null,
       justAdded: false,
+      expandList: [],
     }
   }
 
@@ -57,6 +58,9 @@ class TabContainer extends Component<any, any> {
     if (this.state.scrollTo) {
       return true
     }
+    if (this.state.expandList.toString() === nextState.expandList.toString()) {
+      return true
+    }
 
     if (
       this.state.menuOpen !== nextState.menuOpen ||
@@ -76,6 +80,18 @@ class TabContainer extends Component<any, any> {
     copy.sort((i1, i2) => i2.order - i1.order)
     this.setState({ justAdded: false })
     return copy.find(i => !i.id)
+  }
+
+  public expanded = (isExpanded: boolean, index: number) => {
+    if (this.state.expandList.length === 0) {
+      const newList: boolean[] = []
+      newList[index] = isExpanded
+      this.setState({ expandList: newList })
+    } else {
+      const newList: boolean[] = this.state.expandList
+      newList[index] = isExpanded
+      this.setState({ expandList: newList })
+    }
   }
 
   public render() {
@@ -125,6 +141,7 @@ class TabContainer extends Component<any, any> {
               Items / Question types:
             </Typography>
             <ItemContainer
+              expanded={this.expanded}
               newest={this.newest()}
               onSortEnd={this.onSortEnd}
               items={this.props.items}
@@ -133,6 +150,7 @@ class TabContainer extends Component<any, any> {
               handleSort={this.onSortEnd}
               remove={this.remove}
               scrollToNew={this.scrollToNewItem}
+              shouldBeExpandedList={this.state.expandList}
             />
 
             <Button id="item" onClick={this.handleMenu}>
@@ -202,6 +220,11 @@ class TabContainer extends Component<any, any> {
 
   private onSortEnd = ({ oldIndex, newIndex, collection }) => {
     this.props.changeOrder(collection, oldIndex, newIndex)
+    const newList: boolean[] = { ...this.state.expandList }
+    const temp: boolean = newList[newIndex]
+    newList[newIndex] = newList[oldIndex]
+    newList[oldIndex] = temp
+    this.setState({ expandList: newList })
   }
 }
 

--- a/packages/dashboard/src/components/TabContainer.tsx
+++ b/packages/dashboard/src/components/TabContainer.tsx
@@ -37,11 +37,12 @@ class TabContainer extends Component<any, any> {
   }
 
   public scrollToNewItem = (itemComponent: HTMLInputElement) => {
-    if (itemComponent) {
-      this.setState({
-        scrollTo: itemComponent,
-      })
+    if (!itemComponent) {
+      return
     }
+    this.setState({
+      scrollTo: itemComponent,
+    })
   }
 
   public componentDidUpdate() {
@@ -50,6 +51,7 @@ class TabContainer extends Component<any, any> {
       this.state.scrollTo.select()
       this.setState({
         scrollTo: null,
+        preExisting: null,
       })
     }
   }
@@ -71,6 +73,12 @@ class TabContainer extends Component<any, any> {
     }
 
     return this.props !== nextProps
+  }
+
+  public newest() {
+    const copy = JSON.parse(JSON.stringify(this.props.items))
+    copy.sort((i1, i2) => i2.order - i1.order)
+    return copy.find(i => !i.id)
   }
 
   public render() {
@@ -120,6 +128,7 @@ class TabContainer extends Component<any, any> {
               Items / Question types:
             </Typography>
             <ItemContainer
+              newest={this.newest()}
               onSortEnd={this.onSortEnd}
               items={this.props.items}
               handleChange={this.props.handleChange}
@@ -169,8 +178,6 @@ class TabContainer extends Component<any, any> {
   }
 
   private addItem = type => event => {
-    const existingAtStart = this.state.existing
-
     this.setState({
       preExisting: this.props.storeItems.map(qi => qi.id),
     })

--- a/packages/dashboard/src/components/TabContainer.tsx
+++ b/packages/dashboard/src/components/TabContainer.tsx
@@ -31,8 +31,8 @@ class TabContainer extends Component<any, any> {
     this.state = {
       menuOpen: false,
       menuAnchor: null,
-      preExisting: null,
       scrollTo: null,
+      justAdded: false,
     }
   }
 
@@ -49,18 +49,11 @@ class TabContainer extends Component<any, any> {
     if (this.state.scrollTo) {
       this.state.scrollTo.focus()
       this.state.scrollTo.select()
-      this.setState({
-        scrollTo: null,
-        preExisting: null,
-      })
+      this.setState({ scrollTo: null })
     }
   }
 
   public shouldComponentUpdate(nextProps, nextState) {
-    if (this.state.preExisting) {
-      return true
-    }
-
     if (this.state.scrollTo) {
       return true
     }
@@ -76,8 +69,12 @@ class TabContainer extends Component<any, any> {
   }
 
   public newest() {
+    if (!this.state.justAdded) {
+      return undefined
+    }
     const copy = JSON.parse(JSON.stringify(this.props.items))
     copy.sort((i1, i2) => i2.order - i1.order)
+    this.setState({ justAdded: false })
     return copy.find(i => !i.id)
   }
 
@@ -179,11 +176,8 @@ class TabContainer extends Component<any, any> {
 
   private addItem = type => event => {
     this.setState({
-      preExisting: this.props.storeItems.map(qi => qi.id),
-    })
-
-    this.setState({
       menuOpen: null,
+      justAdded: true,
     })
     this.props.addItem(type)
   }

--- a/packages/dashboard/src/components/TabContainer.tsx
+++ b/packages/dashboard/src/components/TabContainer.tsx
@@ -219,12 +219,12 @@ class TabContainer extends Component<any, any> {
   }
 
   private onSortEnd = ({ oldIndex, newIndex, collection }) => {
-    this.props.changeOrder(collection, oldIndex, newIndex)
     const newList: boolean[] = { ...this.state.expandList }
     const temp: boolean = newList[newIndex]
     newList[newIndex] = newList[oldIndex]
     newList[oldIndex] = temp
     this.setState({ expandList: newList })
+    this.props.changeOrder(collection, oldIndex, newIndex)
   }
 }
 

--- a/packages/dashboard/src/store/edit/actions.ts
+++ b/packages/dashboard/src/store/edit/actions.ts
@@ -21,9 +21,13 @@ export const create = createAction("edit/NEW", resolve => {
 export const setEdit = (quiz: any) => {
   const orderedQuiz = JSON.parse(JSON.stringify(quiz))
   orderedQuiz.items = orderedQuiz.items.sort((i1, i2) => i1.order - i2.order)
-  orderedQuiz.items.map(
-    item => (item.options = item.options.sort((o1, o2) => o1.order - o2.order)),
-  )
+  orderedQuiz.items.map(item => {
+    const newItem = {
+      options: item.options.sort((o1, o2) => o1.order - o2.order),
+      ...item,
+    }
+    return newItem
+  })
   /*orderedQuiz.peerReviewQuestions = orderedQuiz.peerReviewQuestions.sort(
     (p1, p2) => p1.order - p2.order,
   )*/

--- a/packages/dashboard/src/store/edit/actions.ts
+++ b/packages/dashboard/src/store/edit/actions.ts
@@ -91,13 +91,12 @@ export const changeAttr = (path, value) => {
 
 export const changeOrder = (path, current, next) => {
   return (dispatch, getState) => {
-    const quiz = getState().edit // JSON.parse(JSON.stringify(getState().edit))
+    const quiz = JSON.parse(JSON.stringify(getState().edit))
     const array = _.get(quiz, path).sort((o1, o2) => o1.order - o2.order)
-    console.log("Before moving: ", array)
     const moved = array.splice(current, 1)[0]
-    console.log("After moving: ", moved)
     array.splice(next, 0, moved)
     array.map((object, index) => (object.order = index))
+
     dispatch(set(quiz))
   }
 }

--- a/packages/dashboard/src/store/edit/actions.ts
+++ b/packages/dashboard/src/store/edit/actions.ts
@@ -91,9 +91,11 @@ export const changeAttr = (path, value) => {
 
 export const changeOrder = (path, current, next) => {
   return (dispatch, getState) => {
-    const quiz = JSON.parse(JSON.stringify(getState().edit))
+    const quiz = getState().edit // JSON.parse(JSON.stringify(getState().edit))
     const array = _.get(quiz, path).sort((o1, o2) => o1.order - o2.order)
+    console.log("Before moving: ", array)
     const moved = array.splice(current, 1)[0]
+    console.log("After moving: ", moved)
     array.splice(next, 0, moved)
     array.map((object, index) => (object.order = index))
     dispatch(set(quiz))

--- a/packages/dashboard/src/store/edit/reducer.ts
+++ b/packages/dashboard/src/store/edit/reducer.ts
@@ -1,3 +1,4 @@
+import { bool, string } from "prop-types"
 import { getType } from "typesafe-actions"
 import {
   INewQuizQuery,
@@ -14,6 +15,8 @@ const initialState = {
   texts: [],
   items: [],
   peerReviewCollections: [],
+  // mostRecentItemId: string,
+  // mostRecentHasBeenShown: bool
 }
 
 export const editReducer = (state = initialState, action) => {

--- a/packages/dashboard/src/store/edit/reducer.ts
+++ b/packages/dashboard/src/store/edit/reducer.ts
@@ -15,8 +15,6 @@ const initialState = {
   texts: [],
   items: [],
   peerReviewCollections: [],
-  // mostRecentItemId: string,
-  // mostRecentHasBeenShown: bool
 }
 
 export const editReducer = (state = initialState, action) => {


### PR DESCRIPTION
Some improvement tests for dashboard: 
* Expanded items have a gray outline to better distinguish every quiz item from each other
* After adding a new item, that item is expanded and its title selected for editing
* Quiz item type is displayed next to the quiz item title (e.g. "History of computing (essay)")
* Collapse button occupies the same space as the expansion button
* Sorting items / options preserves their expansion state
* Small UI changes