### PR TITLE
Fix for checkbox-dependent widget

### DIFF
--- a/packages/widgets/src/components/Checkbox/CheckboxOption.jsx
+++ b/packages/widgets/src/components/Checkbox/CheckboxOption.jsx
@@ -1,7 +1,7 @@
 import React from "react"
-import { Grid, Checkbox } from "@material-ui/core"
+import { Grid, Checkbox, Typography } from "@material-ui/core"
 
-export default ({ label, value, toggle, answered }) => {
+export default ({ body, title, value, toggle, answered }) => {
   const checkboxOptions = {
     disabled: answered,
     checked: value !== undefined,
@@ -18,7 +18,10 @@ export default ({ label, value, toggle, answered }) => {
         />
       </Grid>
       <Grid item xs style={{ alignSelf: "center" }}>
-        {label}
+        {title && <Typography variant="subtitle1">{title}</Typography>}
+        {body && body !== title && (
+          <Typography variant="body1">{body}</Typography>
+        )}
       </Grid>
     </Grid>
   )

--- a/packages/widgets/src/components/Checkbox/index.jsx
+++ b/packages/widgets/src/components/Checkbox/index.jsx
@@ -1,18 +1,33 @@
+import Typography from "@material-ui/core/Typography"
 import React from "react"
 import CheckboxOption from "./CheckboxOption"
 
 export default ({
   answered,
+  itemBody,
+  itemTitle,
   options,
   optionAnswers,
   handleCheckboxToggling,
 }) => {
   return (
-    <CheckboxOption
-      label={options[0].texts[0].title}
-      value={optionAnswers[0]}
-      toggle={handleCheckboxToggling(options[0].id)}
-      answered={answered}
-    />
+    <React.Fragment>
+      <Typography variant="h6" style={{ paddingBottom: 10 }}>
+        {itemTitle}
+      </Typography>
+      {itemBody && (
+        <Typography
+          variant="body1"
+          style={{ paddingBottom: 10 }}
+          dangerouslySetInnerHTML={{ __html: itemBody }}
+        />
+      )}
+      <CheckboxOption
+        label={options[0].texts[0].title}
+        value={optionAnswers[0]}
+        toggle={handleCheckboxToggling(options[0].id)}
+        answered={answered}
+      />
+    </React.Fragment>
   )
 }

--- a/packages/widgets/src/components/Checkbox/index.jsx
+++ b/packages/widgets/src/components/Checkbox/index.jsx
@@ -1,33 +1,19 @@
-import Typography from "@material-ui/core/Typography"
 import React from "react"
 import CheckboxOption from "./CheckboxOption"
 
 export default ({
   answered,
-  itemBody,
-  itemTitle,
   options,
   optionAnswers,
   handleCheckboxToggling,
 }) => {
   return (
-    <React.Fragment>
-      <Typography variant="h6" style={{ paddingBottom: 10 }}>
-        {itemTitle}
-      </Typography>
-      {itemBody && (
-        <Typography
-          variant="body1"
-          style={{ paddingBottom: 10 }}
-          dangerouslySetInnerHTML={{ __html: itemBody }}
-        />
-      )}
-      <CheckboxOption
-        label={options[0].texts[0].title}
-        value={optionAnswers[0]}
-        toggle={handleCheckboxToggling(options[0].id)}
-        answered={answered}
-      />
-    </React.Fragment>
+    <CheckboxOption
+      title={options[0].texts[0].title}
+      body={options[0].texts[0].title}
+      value={optionAnswers[0]}
+      toggle={handleCheckboxToggling(options[0].id)}
+      answered={answered}
+    />
   )
 }

--- a/packages/widgets/src/components/MultipleChoice.jsx
+++ b/packages/widgets/src/components/MultipleChoice.jsx
@@ -16,6 +16,7 @@ export default props => {
     failureMessage,
     handleOptionChange,
     itemTitle,
+    itemBody,
     multi,
     options,
     optionAnswers,
@@ -46,7 +47,18 @@ export default props => {
         {singleItem ? (
           ""
         ) : (
-          <Typography variant="subtitle1">{itemTitle}</Typography>
+          <React.Fragment>
+            <Typography variant="h6" style={{ paddingBottom: 10 }}>
+              {itemTitle}
+            </Typography>
+            {itemBody && (
+              <Typography
+                variant="body1"
+                style={{ paddingBottom: 10 }}
+                dangerouslySetInnerHTML={{ __html: itemBody }}
+              />
+            )}
+          </React.Fragment>
         )}
         {multi && !answered ? (
           <Typography variant="subtitle1">

--- a/packages/widgets/src/components/ResearchAgreement.jsx
+++ b/packages/widgets/src/components/ResearchAgreement.jsx
@@ -1,10 +1,7 @@
-import Typography from "@material-ui/core/Typography"
 import React from "react"
 import CheckboxOption from "./Checkbox/CheckboxOption"
 
 const ResearchAgreement = ({
-  itemBody,
-  itemTitle,
   options,
   optionAnswers,
   answered,
@@ -18,25 +15,14 @@ const ResearchAgreement = ({
         )
 
         return (
-          <React.Fragment key={option.id}>
-            <Typography variant="h6" style={{ paddingBottom: 10 }}>
-              {itemTitle}
-            </Typography>
-            {itemBody && (
-              <Typography
-                variant="body1"
-                style={{ paddingBottom: 10 }}
-                dangerouslySetInnerHTML={{ __html: itemBody }}
-              />
-            )}
-
-            <CheckboxOption
-              label={option.texts[0].title}
-              value={currentAnswer}
-              toggle={handleCheckboxToggling(option.id)}
-              answered={answered}
-            />
-          </React.Fragment>
+          <CheckboxOption
+            key={option.id}
+            title={option.texts[0].title}
+            body={option.texts[0].body}
+            value={currentAnswer}
+            toggle={handleCheckboxToggling(option.id)}
+            answered={answered}
+          />
         )
       })}
     </React.Fragment>

--- a/packages/widgets/src/components/ResearchAgreement.jsx
+++ b/packages/widgets/src/components/ResearchAgreement.jsx
@@ -1,7 +1,10 @@
+import Typography from "@material-ui/core/Typography"
 import React from "react"
 import CheckboxOption from "./Checkbox/CheckboxOption"
 
 const ResearchAgreement = ({
+  itemBody,
+  itemTitle,
   options,
   optionAnswers,
   answered,
@@ -15,13 +18,25 @@ const ResearchAgreement = ({
         )
 
         return (
-          <CheckboxOption
-            key={option.id}
-            label={option.texts[0].title}
-            value={currentAnswer}
-            toggle={handleCheckboxToggling(option.id)}
-            answered={answered}
-          />
+          <React.Fragment key={option.id}>
+            <Typography variant="h6" style={{ paddingBottom: 10 }}>
+              {itemTitle}
+            </Typography>
+            {itemBody && (
+              <Typography
+                variant="body1"
+                style={{ paddingBottom: 10 }}
+                dangerouslySetInnerHTML={{ __html: itemBody }}
+              />
+            )}
+
+            <CheckboxOption
+              label={option.texts[0].title}
+              value={currentAnswer}
+              toggle={handleCheckboxToggling(option.id)}
+              answered={answered}
+            />
+          </React.Fragment>
         )
       })}
     </React.Fragment>

--- a/packages/widgets/src/components/index.jsx
+++ b/packages/widgets/src/components/index.jsx
@@ -256,6 +256,7 @@ class Quiz extends Component {
                 handleTextDataChange={this.handleTextDataChange(item.id)}
                 handleIntDataChange={this.handleIntDataChange(item.id)}
                 handleOptionChange={this.handleOptionChange(item.id)}
+                handleCheckboxToggling={this.handleCheckboxToggling(item.id)}
                 setUserQuizState={this.setUserQuizState}
               />
             )


### PR DESCRIPTION
Happened to notice that any widget containing checkbox-type options don't work, so a small fix was in order. Also added quiz item title to all types of quiz items. Odd that the whole thing was so broken :no_mouth: 