### PR TITLE
Paging for answers on quiz page

### DIFF
--- a/packages/backend/src/controllers/quizanswers/index.ts
+++ b/packages/backend/src/controllers/quizanswers/index.ts
@@ -70,6 +70,8 @@ export class QuizAnswerController {
     @QueryParam("attention") attention: boolean,
     @QueryParam("quizId") quizId: string,
     @HeaderParam("authorization") user: ITMCProfileDetails,
+    @QueryParam("skip") skip?: number,
+    @QueryParam("limit") limit?: number,
   ): Promise<QuizAnswer[]> {
     if (!user.administrator) {
       throw new UnauthorizedError("unauthorized")

--- a/packages/backend/src/controllers/quizanswers/index.ts
+++ b/packages/backend/src/controllers/quizanswers/index.ts
@@ -46,12 +46,15 @@ export class QuizAnswerController {
   @Get("/counts")
   public async getAnswerCounts(
     @HeaderParam("authorization") user: ITMCProfileDetails,
+    @QueryParam("quizId") quizId?: string,
   ): Promise<any[]> {
     if (!user.administrator) {
       throw new UnauthorizedError("unauthorized")
     }
 
-    return await this.quizAnswerService.getAttentionAnswersCount()
+    return quizId
+      ? await this.quizAnswerService.getNumberOfAnswers(quizId)
+      : await this.quizAnswerService.getAttentionAnswersCount()
   }
 
   @Get("/statistics")

--- a/packages/backend/src/controllers/quizanswers/index.ts
+++ b/packages/backend/src/controllers/quizanswers/index.ts
@@ -21,6 +21,8 @@ import { API_PATH } from "../../config"
 import { Quiz, QuizAnswer, User, UserQuizState } from "../../models"
 import { ITMCProfileDetails } from "../../types"
 
+const MAX_LIMIT = 100
+
 @JsonController(`${API_PATH}/quizzes/answer`)
 export class QuizAnswerController {
   @InjectManager()
@@ -79,9 +81,23 @@ export class QuizAnswerController {
 
     let result: QuizAnswer[]
 
+    if (limit >= MAX_LIMIT) {
+      limit = MAX_LIMIT
+    }
+
     result = attention
-      ? await this.quizAnswerService.getAttentionAnswers(quizId, true)
-      : await this.quizAnswerService.getEveryonesAnswers(quizId, true)
+      ? await this.quizAnswerService.getAttentionAnswers(
+          quizId,
+          skip,
+          limit,
+          true,
+        )
+      : await this.quizAnswerService.getEveryonesAnswers(
+          quizId,
+          skip,
+          limit,
+          true,
+        )
 
     return result
   }

--- a/packages/backend/src/services/quizanswer.service.ts
+++ b/packages/backend/src/services/quizanswer.service.ts
@@ -141,7 +141,7 @@ export default class QuizAnswerService {
       .where("quiz_answer.quiz_id = :quiz_id", { quiz_id: quizId })
       .andWhere("quiz_answer.status IN ('spam', 'submitted')")
       .skip(skip)
-      .limit(limit)
+      .take(limit)
 
     return await query.getMany()
   }

--- a/packages/backend/src/services/quizanswer.service.ts
+++ b/packages/backend/src/services/quizanswer.service.ts
@@ -156,12 +156,18 @@ export default class QuizAnswerService {
   }
 
   public async getNumberOfAnswers(quizId: string): Promise<any> {
-    return await QuizAnswer.createQueryBuilder("quiz_answer")
+    const result = await QuizAnswer.createQueryBuilder("quiz_answer")
       .select("quiz_answer.quiz_id", "quizId")
       .addSelect("COUNT(quiz_answer.id)")
       .where("quiz_answer.quiz_id = :quiz_id", { quiz_id: quizId })
       .groupBy("quiz_answer.quiz_id")
       .getRawMany()
+
+    if (result.length === 0) {
+      return {}
+    }
+
+    return result[0]
   }
 
   public async getAnswersStatistics(quizId: string): Promise<any> {

--- a/packages/backend/src/services/quizanswer.service.ts
+++ b/packages/backend/src/services/quizanswer.service.ts
@@ -148,9 +148,18 @@ export default class QuizAnswerService {
 
   public async getAttentionAnswersCount(): Promise<any[]> {
     return await QuizAnswer.createQueryBuilder("quiz_answer")
-      .select("quiz_answer.quiz_id")
+      .select("quiz_answer.quiz_id", "quizId")
       .addSelect("COUNT(quiz_answer.id)")
       .where("quiz_answer.status IN ('spam', 'submitted')")
+      .groupBy("quiz_answer.quiz_id")
+      .getRawMany()
+  }
+
+  public async getNumberOfAnswers(quizId: string): Promise<any> {
+    return await QuizAnswer.createQueryBuilder("quiz_answer")
+      .select("quiz_answer.quiz_id", "quizId")
+      .addSelect("COUNT(quiz_answer.id)")
+      .where("quiz_answer.quiz_id = :quiz_id", { quiz_id: quizId })
       .groupBy("quiz_answer.quiz_id")
       .getRawMany()
   }

--- a/packages/backend/src/services/quizanswer.service.ts
+++ b/packages/backend/src/services/quizanswer.service.ts
@@ -93,10 +93,11 @@ export default class QuizAnswerService {
 
   public async getEveryonesAnswers(
     quizId: string,
+    skip = 0,
+    limit = 50,
     addPeerReviews?: boolean,
   ): Promise<QuizAnswer[]> {
     let query = QuizAnswer.createQueryBuilder("quiz_answer")
-
     if (addPeerReviews) {
       query = query
         .leftJoinAndMapMany(
@@ -111,12 +112,16 @@ export default class QuizAnswerService {
     query = query
       .where("quiz_answer.quiz_id = :quiz_id", { quiz_id: quizId })
       .andWhere("quiz_answer.status IN ('spam', 'submitted')")
+      .skip(skip)
+      .take(limit)
 
     return await query.getMany()
   }
 
   public async getAttentionAnswers(
     quizId: string,
+    skip = 0,
+    limit = 50,
     addPeerReviews?: boolean,
   ): Promise<QuizAnswer[]> {
     let query = QuizAnswer.createQueryBuilder("quiz_answer")
@@ -135,6 +140,8 @@ export default class QuizAnswerService {
     query = query
       .where("quiz_answer.quiz_id = :quiz_id", { quiz_id: quizId })
       .andWhere("quiz_answer.status IN ('spam', 'submitted')")
+      .skip(skip)
+      .limit(limit)
 
     return await query.getMany()
   }

--- a/packages/backend/src/services/quizanswer.service.ts
+++ b/packages/backend/src/services/quizanswer.service.ts
@@ -111,7 +111,6 @@ export default class QuizAnswerService {
 
     query = query
       .where("quiz_answer.quiz_id = :quiz_id", { quiz_id: quizId })
-      .andWhere("quiz_answer.status IN ('spam', 'submitted')")
       .skip(skip)
       .take(limit)
 

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -26,7 +26,6 @@ import { setCourses } from "./store/courses/actions"
 import { newQuiz, setEdit } from "./store/edit/actions"
 import { setCourse } from "./store/filter/actions"
 import { displayMessage } from "./store/notification/actions"
-import { setQuizzes } from "./store/quizzes/actions"
 import { addUser, removeUser } from "./store/user/actions"
 
 class App extends React.Component<any, any> {
@@ -50,11 +49,13 @@ class App extends React.Component<any, any> {
   }
 
   public currentQuizTitle: () => string | null = () => {
-    if (!this.props.filter.quiz) {
+    if (!this.props.filter.quiz || !this.props.quizzesOfCourse) {
       return null
     }
 
-    const quiz = this.props.quizzes.find(q => q.id === this.props.filter.quiz)
+    const quiz = this.props.quizzesOfCourse.quizzes.find(
+      q => q.id === this.props.filter.quiz,
+    )
     return quiz ? quiz.texts[0].title : null
   }
 
@@ -238,10 +239,12 @@ class App extends React.Component<any, any> {
   }
 
   private edit = ({ match }) => {
-    if (this.props.quizzes.length === 0) {
+    if (!this.props.quizzesOfCourse) {
       return <p />
     }
-    const quiz = this.props.quizzes.find(q => q.id === match.params.id)
+    const quiz = this.props.quizzesOfCourse.quizzes.find(
+      q => q.id === match.params.id,
+    )
     return <QuizForm quiz={quiz} new={false} />
   }
 
@@ -289,7 +292,6 @@ interface IDispatchProps {
   setCourse: typeof setCourse
   setCourses: typeof setCourses
   setEdit: typeof setEdit
-  setQuizzes: typeof setQuizzes
   removeUser: typeof removeUser
 }
 
@@ -297,7 +299,7 @@ interface IStateProps {
   courses: any
   edit: any
   filter: any
-  quizzes: any[]
+  quizzesOfCourse: any
   user: ITMCProfile
 }
 
@@ -307,7 +309,9 @@ const mapStateToProps = (state: any) => {
     courses: state.courses,
     edit: state.edit,
     filter: state.filter,
-    quizzes: state.quizzes,
+    quizzesOfCourse: state.quizzes.find(
+      courseQuizInfo => courseQuizInfo.courseId === state.filter.course,
+    ),
     user: state.user,
   }
 }
@@ -320,7 +324,6 @@ const mapDispatchToProps = {
   setCourse,
   setCourses,
   setEdit,
-  setQuizzes,
   removeUser,
 }
 

--- a/packages/dashboard/src/components/Answers/Answer.tsx
+++ b/packages/dashboard/src/components/Answers/Answer.tsx
@@ -326,7 +326,8 @@ class PeerReviewsSummary extends React.Component<any, any> {
 const mapStateToProps = state => {
   return {
     answerStatistics: state.answerStatistics,
-    quizzes: state.quizzes,
+    quizzes: state.quizzes.find(qi => qi.courseId === state.filter.course)
+      .quizzes,
   }
 }
 

--- a/packages/dashboard/src/components/Answers/Answer.tsx
+++ b/packages/dashboard/src/components/Answers/Answer.tsx
@@ -59,13 +59,16 @@ class Answer extends React.Component<any, any> {
                 />
               </Grid>
 
-              {!this.state.expanded && (
-                <Grid item={true} xs="auto">
-                  <IconButton onClick={this.showMore}>
-                    <MoreVert />
-                  </IconButton>
-                </Grid>
-              )}
+              {!this.state.expanded &&
+                ((this.props.quiz.peerReviewCollections &&
+                  this.props.quiz.peerReviewCollections.length > 0) ||
+                  !this.itemAnswersDisplayedInFull(this.props.answerData)) && (
+                  <Grid item={true} xs="auto">
+                    <IconButton onClick={this.showMore}>
+                      <MoreVert />
+                    </IconButton>
+                  </Grid>
+                )}
 
               {this.state.expanded && (
                 <React.Fragment>
@@ -152,6 +155,14 @@ class Answer extends React.Component<any, any> {
     )
   }
 
+  private itemAnswersDisplayedInFull = (answer): boolean => {
+    const limit = 1500
+    console.log("Answer data: ", answer)
+    return !answer.itemAnswers.some(
+      ia => ia.textData && ia.textData.length > limit,
+    )
+  }
+
   private average = (allPeerReviews: any): number | undefined => {
     const allGrades = allPeerReviews
       .map(pr => pr.answers)
@@ -218,7 +229,7 @@ class PeerReviewsSummary extends React.Component<any, any> {
   public render() {
     if (this.props.peerReviewsQuestions.length === 0) {
       return (
-        <Grid item={true} xs={12}>
+        <Grid item={true} xs="auto">
           <Typography variant="title">Quiz involves no peer reviews</Typography>
         </Grid>
       )
@@ -230,7 +241,7 @@ class PeerReviewsSummary extends React.Component<any, any> {
           container={true}
           justify="flex-start"
           alignItems="stretch"
-          spacing={16}
+          spacing={8}
         >
           <Grid
             item={true}
@@ -238,30 +249,41 @@ class PeerReviewsSummary extends React.Component<any, any> {
             md={3}
             style={{ borderRight: "1px dashed #9D9696" }}
           >
-            <Typography variant="subtitle1" color="textSecondary">
-              SPAM FLAGS: {this.props.spamFlags}
-            </Typography>
-            <Button variant="outlined" onClick={this.openModal}>
-              VIEW PEER REVIEWS
-            </Button>
+            <Grid
+              container={true}
+              direction="column"
+              spacing={24}
+              justify="space-around"
+              alignItems="center"
+            >
+              <Grid item={true} xs={12}>
+                <Typography variant="subtitle1" color="textSecondary">
+                  SPAM FLAGS: {this.props.spamFlags}
+                </Typography>
+              </Grid>
+
+              <Grid item={true} xs={12}>
+                <Button variant="outlined" onClick={this.openModal}>
+                  VIEW PEER REVIEWS
+                </Button>
+              </Grid>
+            </Grid>
           </Grid>
 
           <Grid item={true} xs={12} md={9}>
             <Grid
               container={true}
               alignItems="center"
-              spacing={24}
-              style={{ marginBottom: "2em" }}
+              spacing={8}
+              style={{ paddingLeft: "1em", paddingBottom: "1em" }}
             >
-              <Grid item={true} xs={4} lg={3} xl={2} />
-              <Grid item={true} xs={4}>
+              <Grid item={true} xs={4} lg={6} />
+              <Grid item={true} xs={4} lg={3}>
                 <Typography variant="subtitle1">AVERAGE POINTS</Typography>
               </Grid>
-              <Grid item={true} xs={4}>
+              <Grid item={true} xs={4} lg={3}>
                 <Typography variant="subtitle1">STANDARD DEVIATION</Typography>
               </Grid>
-
-              <Grid item={true} xs="auto" lg={1} xl={2} />
 
               {this.props.peerReviewsAnswers &&
                 (this.props.peerReviewsAnswers.length === 0 ||
@@ -280,25 +302,24 @@ class PeerReviewsSummary extends React.Component<any, any> {
 
                   return (
                     <React.Fragment key={question.id}>
-                      <Grid item={true} xs={4} lg={3} xl={2}>
+                      <Grid item={true} xs={4} lg={6}>
                         {question.texts[0].title || "No title"}
                         {question.type === "essay" && " (Essay)"}:
                       </Grid>
-                      <Grid item={true} xs={4}>
+                      <Grid item={true} xs={4} lg={3}>
                         {question.type === "essay"
                           ? "NA"
                           : average === undefined
                           ? "-"
                           : average.toFixed(2)}
                       </Grid>
-                      <Grid item={true} xs={4}>
+                      <Grid item={true} xs={4} lg={3}>
                         {question.type === "essay"
                           ? "NA"
                           : sd === undefined
                           ? "-"
                           : sd.toFixed(2)}
                       </Grid>
-                      <Grid item={true} xs="auto" lg={1} xl={2} />
                     </React.Fragment>
                   )
                 })}

--- a/packages/dashboard/src/components/Answers/Answer.tsx
+++ b/packages/dashboard/src/components/Answers/Answer.tsx
@@ -76,9 +76,9 @@ class Answer extends React.Component<any, any> {
                 justify="space-between"
                 style={{ margin: ".5em .25em .25em .25em" }}
               >
-                <Grid item={true} xs={4} md={3}>
-                  <Grid container={true} spacing={16}>
-                    <Grid item={true} xs={6}>
+                <Grid item={true} xs={6} lg={4}>
+                  <Grid container={true} justify="flex-start" spacing={16}>
+                    <Grid item={true} xs="auto">
                       <Button
                         variant="contained"
                         style={{
@@ -91,7 +91,7 @@ class Answer extends React.Component<any, any> {
                       </Button>
                     </Grid>
 
-                    <Grid item={true} xs={6}>
+                    <Grid item={true} xs="auto">
                       <Button
                         variant="contained"
                         style={{

--- a/packages/dashboard/src/components/Answers/Answer.tsx
+++ b/packages/dashboard/src/components/Answers/Answer.tsx
@@ -97,7 +97,10 @@ class Answer extends React.Component<any, any> {
                   container={true}
                   spacing={8}
                   justify="space-between"
-                  style={{ margin: ".5em .25em .25em .25em" }}
+                  style={{
+                    padding: ".5em .5em .25em .5em",
+                    // margin: ".5em 0em .25em 0em"
+                  }}
                 >
                   <Grid item={true} xs={6} lg={4}>
                     <Grid container={true} justify="flex-start" spacing={16}>

--- a/packages/dashboard/src/components/Answers/Answer.tsx
+++ b/packages/dashboard/src/components/Answers/Answer.tsx
@@ -50,7 +50,7 @@ class Answer extends React.Component<any, any> {
             }}
           >
             <Grid container={true} justify="center">
-              <Grid item={true} xs={12}>
+              <Grid item={true} xs={12} style={{ paddingRight: "1em" }}>
                 <ItemAnswer
                   idx={this.props.idx}
                   answer={this.props.answerData}
@@ -99,7 +99,6 @@ class Answer extends React.Component<any, any> {
                   justify="space-between"
                   style={{
                     padding: ".5em .5em .25em .5em",
-                    // margin: ".5em 0em .25em 0em"
                   }}
                 >
                   <Grid item={true} xs={6} lg={4}>

--- a/packages/dashboard/src/components/Answers/Answer.tsx
+++ b/packages/dashboard/src/components/Answers/Answer.tsx
@@ -157,7 +157,6 @@ class Answer extends React.Component<any, any> {
 
   private itemAnswersDisplayedInFull = (answer): boolean => {
     const limit = 1500
-    console.log("Answer data: ", answer)
     return !answer.itemAnswers.some(
       ia => ia.textData && ia.textData.length > limit,
     )

--- a/packages/dashboard/src/components/Answers/Answer.tsx
+++ b/packages/dashboard/src/components/Answers/Answer.tsx
@@ -245,7 +245,7 @@ class PeerReviewsSummary extends React.Component<any, any> {
                   return (
                     <React.Fragment key={question.id}>
                       <Grid item={true} xs={4} lg={3} xl={2}>
-                        {question.texts[0].title || "No title"}{" "}
+                        {question.texts[0].title || "No title"}
                         {question.type === "essay" && " (Essay)"}:
                       </Grid>
                       <Grid item={true} xs={4}>

--- a/packages/dashboard/src/components/Answers/Answer.tsx
+++ b/packages/dashboard/src/components/Answers/Answer.tsx
@@ -14,10 +14,6 @@ class Answer extends React.Component<any, any> {
     }
   }
 
-  public componentDidMount() {
-    this.props.setQuiz(this.props.answerData.quizId)
-  }
-
   public render() {
     const peerAverage = this.average(this.props.answerData.peerReviews)
     const peerSd = this.standardDeviation(this.props.answerData.peerReviews)

--- a/packages/dashboard/src/components/Answers/Answer.tsx
+++ b/packages/dashboard/src/components/Answers/Answer.tsx
@@ -1,4 +1,13 @@
-import { Button, Card, Grid, Typography } from "@material-ui/core"
+import {
+  Button,
+  Card,
+  Grid,
+  IconButton,
+  RootRef,
+  Typography,
+} from "@material-ui/core"
+import ExpandLess from "@material-ui/icons/ExpandLess"
+import MoreVert from "@material-ui/icons/MoreVert"
 import React from "react"
 import { connect } from "react-redux"
 import { setCourse, setQuiz } from "../../store/filter/actions"
@@ -6,8 +15,11 @@ import ItemAnswer from "./ItemAnswer"
 import PeerReviewsModal from "./PeerReviewsModal"
 
 class Answer extends React.Component<any, any> {
+  private answerRef: React.RefObject<HTMLElement>
+
   constructor(props) {
     super(props)
+    this.answerRef = React.createRef<HTMLElement>()
     this.state = {
       expanded: false,
       modalOpen: false,
@@ -23,106 +35,118 @@ class Answer extends React.Component<any, any> {
     ).peerReviewCollections
 
     return (
-      <Grid
-        item={true}
-        xs={12}
-        style={{ marginRight: "1em" }}
-        onMouseEnter={this.showMore}
-        onMouseLeave={this.showLess}
-      >
-        <Card
-          raised={true}
-          square={true}
-          style={{
-            borderLeft:
-              "1em solid " +
-              (this.props.answerData.status === "submitted" ||
-              this.props.answerData.status === "spam"
-                ? "#FB6949"
-                : "#49C7FB"),
-          }}
-        >
-          <Grid container={true}>
-            <Grid item={true} xs={12}>
-              <ItemAnswer
-                idx={this.props.idx}
-                answer={this.props.answerData}
-                quiz={this.props.quiz}
-              />
-            </Grid>
+      <RootRef rootRef={this.answerRef}>
+        <Grid item={true} xs={12} style={{ marginRight: "1em" }}>
+          <Card
+            raised={true}
+            square={true}
+            style={{
+              borderLeft:
+                "1em solid " +
+                (this.props.answerData.status === "submitted" ||
+                this.props.answerData.status === "spam"
+                  ? "#FB6949"
+                  : "#49C7FB"),
+            }}
+          >
+            <Grid container={true} justify="center">
+              <Grid item={true} xs={12}>
+                <ItemAnswer
+                  idx={this.props.idx}
+                  answer={this.props.answerData}
+                  quiz={this.props.quiz}
+                  fullLength={this.state.expanded}
+                />
+              </Grid>
 
-            {this.state.expanded && (
-              <PeerReviewsSummary
-                peerReviewsAnswers={this.props.peerReviews}
-                peerReviewsQuestions={
-                  peerReviewCollections.length > 0
-                    ? peerReviewCollections[0].questions
-                    : []
-                }
-                answer={this.props.answerData}
-                spamFlags={
-                  this.props.answerStatistics.find(
-                    as => as.quiz_answer_id === this.props.answerData.id,
-                  ).count
-                }
-                setQuiz={this.props.setQuiz}
-              />
-            )}
+              {!this.state.expanded && (
+                <Grid item={true} xs="auto">
+                  <IconButton onClick={this.showMore}>
+                    <MoreVert />
+                  </IconButton>
+                </Grid>
+              )}
 
-            <Grid item={true} xs={12} style={{ backgroundColor: "#E5E5E5" }}>
-              <Grid
-                container={true}
-                spacing={8}
-                justify="space-between"
-                style={{ margin: ".5em .25em .25em .25em" }}
-              >
-                <Grid item={true} xs={6} lg={4}>
-                  <Grid container={true} justify="flex-start" spacing={16}>
-                    <Grid item={true} xs="auto">
-                      <Button
-                        variant="contained"
-                        style={{
-                          backgroundColor: "#029422",
-                          borderRadius: "0",
-                          color: "white",
-                        }}
-                      >
-                        Accept
-                      </Button>
-                    </Grid>
+              {this.state.expanded && (
+                <React.Fragment>
+                  <PeerReviewsSummary
+                    peerReviewsAnswers={this.props.peerReviews}
+                    peerReviewsQuestions={
+                      peerReviewCollections.length > 0
+                        ? peerReviewCollections[0].questions
+                        : []
+                    }
+                    answer={this.props.answerData}
+                    spamFlags={
+                      this.props.answerStatistics.find(
+                        as => as.quiz_answer_id === this.props.answerData.id,
+                      ).count
+                    }
+                    setQuiz={this.props.setQuiz}
+                  />
+                  <Grid item={true} xs="auto">
+                    <IconButton onClick={this.showLess}>
+                      <ExpandLess />
+                    </IconButton>
+                  </Grid>
+                </React.Fragment>
+              )}
 
-                    <Grid item={true} xs="auto">
-                      <Button
-                        variant="contained"
-                        style={{
-                          backgroundColor: "#D80027",
-                          borderRadius: "0",
-                          color: "white",
-                        }}
-                      >
-                        Reject
-                      </Button>
+              <Grid item={true} xs={12} style={{ backgroundColor: "#E5E5E5" }}>
+                <Grid
+                  container={true}
+                  spacing={8}
+                  justify="space-between"
+                  style={{ margin: ".5em .25em .25em .25em" }}
+                >
+                  <Grid item={true} xs={6} lg={4}>
+                    <Grid container={true} justify="flex-start" spacing={16}>
+                      <Grid item={true} xs="auto">
+                        <Button
+                          variant="contained"
+                          style={{
+                            backgroundColor: "#029422",
+                            borderRadius: "0",
+                            color: "white",
+                          }}
+                        >
+                          Accept
+                        </Button>
+                      </Grid>
+
+                      <Grid item={true} xs="auto">
+                        <Button
+                          variant="contained"
+                          style={{
+                            backgroundColor: "#D80027",
+                            borderRadius: "0",
+                            color: "white",
+                          }}
+                        >
+                          Reject
+                        </Button>
+                      </Grid>
                     </Grid>
                   </Grid>
-                </Grid>
 
-                <Grid item={true} xs={2} style={{ textAlign: "center" }}>
-                  <Typography>
-                    Avg:{" "}
-                    {peerAverage || peerAverage === 0
-                      ? peerAverage.toFixed(2)
-                      : "-"}
-                  </Typography>
+                  <Grid item={true} xs={2} style={{ textAlign: "center" }}>
+                    <Typography>
+                      Avg:{" "}
+                      {peerAverage || peerAverage === 0
+                        ? peerAverage.toFixed(2)
+                        : "-"}
+                    </Typography>
 
-                  <Typography>
-                    SD: {peerSd || peerSd === 0 ? peerSd.toFixed(2) : "-"}
-                  </Typography>
+                    <Typography>
+                      SD: {peerSd || peerSd === 0 ? peerSd.toFixed(2) : "-"}
+                    </Typography>
+                  </Grid>
                 </Grid>
               </Grid>
             </Grid>
-          </Grid>
-        </Card>
-      </Grid>
+          </Card>
+        </Grid>
+      </RootRef>
     )
   }
 
@@ -167,6 +191,14 @@ class Answer extends React.Component<any, any> {
   }
 
   private showLess = () => {
+    if (!this.answerRef.current) {
+      return
+    }
+    scrollTo({
+      left: 0,
+      top: this.answerRef.current.offsetTop - 100,
+      behavior: "smooth",
+    })
     this.setState({
       expanded: false,
     })
@@ -184,7 +216,9 @@ class PeerReviewsSummary extends React.Component<any, any> {
   public render() {
     if (this.props.peerReviewsQuestions.length === 0) {
       return (
-        <Typography variant="title">Quiz involves no peer reviews</Typography>
+        <Grid item={true} xs={12}>
+          <Typography variant="title">Quiz involves no peer reviews</Typography>
+        </Grid>
       )
     }
 

--- a/packages/dashboard/src/components/Answers/Answers.tsx
+++ b/packages/dashboard/src/components/Answers/Answers.tsx
@@ -42,33 +42,41 @@ const AttentionAnswers = ({
         )}
       </Grid>
 
-      <Grid item={true} xs="auto">
-        <PageSelector
-          currentPage={currentPage}
-          totalPages={totalPages}
-          onPageChange={onPageChange}
-        />
-      </Grid>
+      {answers.length === 0 ? (
+        <Grid item={true} xs={12}>
+          <Typography variant="subtitle1">No answers</Typography>
+        </Grid>
+      ) : (
+        <React.Fragment>
+          <Grid item={true} xs="auto">
+            <PageSelector
+              currentPage={currentPage}
+              totalPages={totalPages}
+              onPageChange={onPageChange}
+            />
+          </Grid>
 
-      {answers.map((answer, idx) => {
-        return (
-          <Answer
-            key={answer.id}
-            answerData={answer}
-            peerReviews={answer.peerReviews}
-            idx={idx}
-            quiz={quiz}
-          />
-        )
-      })}
+          {answers.map((answer, idx) => {
+            return (
+              <Answer
+                key={answer.id}
+                answerData={answer}
+                peerReviews={answer.peerReviews}
+                idx={idx}
+                quiz={quiz}
+              />
+            )
+          })}
 
-      <Grid item={true} xs="auto">
-        <PageSelector
-          currentPage={currentPage}
-          totalPages={totalPages}
-          onPageChange={onPageChange}
-        />
-      </Grid>
+          <Grid item={true} xs="auto">
+            <PageSelector
+              currentPage={currentPage}
+              totalPages={totalPages}
+              onPageChange={onPageChange}
+            />
+          </Grid>
+        </React.Fragment>
+      )}
     </Grid>
   )
 }

--- a/packages/dashboard/src/components/Answers/Answers.tsx
+++ b/packages/dashboard/src/components/Answers/Answers.tsx
@@ -64,17 +64,38 @@ class AttentionAnswers extends React.Component<any, any> {
               </RootRef>
             </Grid>
 
-            {this.props.answers.map((answer, idx) => {
-              return (
-                <Answer
-                  key={answer.id}
-                  answerData={answer}
-                  peerReviews={answer.peerReviews}
-                  idx={idx}
-                  quiz={this.props.quiz}
-                />
-              )
-            })}
+            <Grid
+              item={true}
+              xs="auto"
+              style={
+                this.props.inWaitingState
+                  ? {
+                      filter: "opacity(25%)",
+                      cursor: "default",
+                      pointerEvents: "none",
+                    }
+                  : {}
+              }
+            >
+              <Grid
+                container={true}
+                justify="flex-start"
+                alignItems="center"
+                spacing={24}
+              >
+                {this.props.answers.map((answer, idx) => {
+                  return (
+                    <Answer
+                      key={answer.id}
+                      answerData={answer}
+                      peerReviews={answer.peerReviews}
+                      idx={idx}
+                      quiz={this.props.quiz}
+                    />
+                  )
+                })}
+              </Grid>
+            </Grid>
 
             <Grid item={true} xs={12}>
               <PageSelector

--- a/packages/dashboard/src/components/Answers/Answers.tsx
+++ b/packages/dashboard/src/components/Answers/Answers.tsx
@@ -74,6 +74,7 @@ const AttentionAnswers = ({
 
           <Grid item={true} xs={12}>
             <PageSelector
+              isAtBottom={true}
               currentPage={currentPage}
               totalPages={totalPages}
               onPageChange={onPageChange}

--- a/packages/dashboard/src/components/Answers/Answers.tsx
+++ b/packages/dashboard/src/components/Answers/Answers.tsx
@@ -11,6 +11,8 @@ const AttentionAnswers = ({
   currentPage,
   totalPages,
   onPageChange,
+  resultsPerPage,
+  changeResultsPerPage,
 }) => {
   return (
     <Grid
@@ -48,11 +50,13 @@ const AttentionAnswers = ({
         </Grid>
       ) : (
         <React.Fragment>
-          <Grid item={true} xs="auto">
+          <Grid item={true} xs={12}>
             <PageSelector
               currentPage={currentPage}
               totalPages={totalPages}
               onPageChange={onPageChange}
+              resultsPerPage={resultsPerPage}
+              changeResultsPerPage={changeResultsPerPage}
             />
           </Grid>
 
@@ -68,11 +72,13 @@ const AttentionAnswers = ({
             )
           })}
 
-          <Grid item={true} xs="auto">
+          <Grid item={true} xs={12}>
             <PageSelector
               currentPage={currentPage}
               totalPages={totalPages}
               onPageChange={onPageChange}
+              resultsPerPage={resultsPerPage}
+              changeResultsPerPage={changeResultsPerPage}
             />
           </Grid>
         </React.Fragment>

--- a/packages/dashboard/src/components/Answers/Answers.tsx
+++ b/packages/dashboard/src/components/Answers/Answers.tsx
@@ -1,91 +1,97 @@
-import { Grid, Typography } from "@material-ui/core"
+import { Grid, RootRef, Typography } from "@material-ui/core"
 import React from "react"
 import { Link } from "react-router-dom"
 import Answer from "./Answer"
 import PageSelector from "./PageSelector"
 
-const AttentionAnswers = ({
-  answers,
-  quiz,
-  showingAll,
-  currentPage,
-  totalPages,
-  onPageChange,
-  resultsPerPage,
-  changeResultsPerPage,
-}) => {
-  return (
-    <Grid
-      container={true}
-      justify="flex-start"
-      alignItems="center"
-      spacing={24}
-    >
+class AttentionAnswers extends React.Component<any, any> {
+  private upperNavigationRef: React.RefObject<HTMLElement>
+
+  constructor(props) {
+    super(props)
+    this.upperNavigationRef = React.createRef<HTMLElement>()
+  }
+
+  public render() {
+    return (
       <Grid
-        item={true}
-        xs={8}
-        style={{ marginBottom: "1em", textAlign: "center" }}
+        container={true}
+        justify="flex-start"
+        alignItems="center"
+        spacing={24}
       >
-        <Typography variant="title">
-          {showingAll ? "ALL ANSWERS" : "ANSWERS REQUIRING ATTENTION"}
-        </Typography>
-      </Grid>
-      <Grid item={true} xs={4}>
-        {showingAll ? (
-          <Link to={`/quizzes/${quiz.id}/answers`}>
-            <Typography color="textPrimary">
-              VIEW ANSWERS REQUIRING ATTENTION
-            </Typography>
-          </Link>
+        <Grid
+          item={true}
+          xs={8}
+          style={{ marginBottom: "1em", textAlign: "center" }}
+        >
+          <Typography variant="title">
+            {this.props.showingAll
+              ? "ALL ANSWERS"
+              : "ANSWERS REQUIRING ATTENTION"}
+          </Typography>
+        </Grid>
+        <Grid item={true} xs={4}>
+          {this.props.showingAll ? (
+            <Link to={`/quizzes/${this.props.quiz.id}/answers`}>
+              <Typography color="textPrimary">
+                VIEW ANSWERS REQUIRING ATTENTION
+              </Typography>
+            </Link>
+          ) : (
+            <Link to={`/quizzes/${this.props.quiz.id}/answers?all=true`}>
+              <Typography color="textPrimary">VIEW ALL</Typography>
+            </Link>
+          )}
+        </Grid>
+
+        {this.props.answers.length === 0 ? (
+          <Grid item={true} xs={12}>
+            <Typography variant="subtitle1">No answers</Typography>
+          </Grid>
         ) : (
-          <Link to={`/quizzes/${quiz.id}/answers?all=true`}>
-            <Typography color="textPrimary">VIEW ALL</Typography>
-          </Link>
+          <React.Fragment>
+            <Grid item={true} xs={12}>
+              <RootRef rootRef={this.upperNavigationRef}>
+                <PageSelector
+                  upRef={null}
+                  currentPage={this.props.currentPage}
+                  totalPages={this.props.totalPages}
+                  onPageChange={this.props.onPageChange}
+                  resultsPerPage={this.props.resultsPerPage}
+                  changeResultsPerPage={this.props.changeResultsPerPage}
+                />
+              </RootRef>
+            </Grid>
+
+            {this.props.answers.map((answer, idx) => {
+              return (
+                <Answer
+                  key={answer.id}
+                  answerData={answer}
+                  peerReviews={answer.peerReviews}
+                  idx={idx}
+                  quiz={this.props.quiz}
+                />
+              )
+            })}
+
+            <Grid item={true} xs={12}>
+              <PageSelector
+                isAtBottom={true}
+                upRef={this.upperNavigationRef}
+                currentPage={this.props.currentPage}
+                totalPages={this.props.totalPages}
+                onPageChange={this.props.onPageChange}
+                resultsPerPage={this.props.resultsPerPage}
+                changeResultsPerPage={this.props.changeResultsPerPage}
+              />
+            </Grid>
+          </React.Fragment>
         )}
       </Grid>
-
-      {answers.length === 0 ? (
-        <Grid item={true} xs={12}>
-          <Typography variant="subtitle1">No answers</Typography>
-        </Grid>
-      ) : (
-        <React.Fragment>
-          <Grid item={true} xs={12}>
-            <PageSelector
-              currentPage={currentPage}
-              totalPages={totalPages}
-              onPageChange={onPageChange}
-              resultsPerPage={resultsPerPage}
-              changeResultsPerPage={changeResultsPerPage}
-            />
-          </Grid>
-
-          {answers.map((answer, idx) => {
-            return (
-              <Answer
-                key={answer.id}
-                answerData={answer}
-                peerReviews={answer.peerReviews}
-                idx={idx}
-                quiz={quiz}
-              />
-            )
-          })}
-
-          <Grid item={true} xs={12}>
-            <PageSelector
-              isAtBottom={true}
-              currentPage={currentPage}
-              totalPages={totalPages}
-              onPageChange={onPageChange}
-              resultsPerPage={resultsPerPage}
-              changeResultsPerPage={changeResultsPerPage}
-            />
-          </Grid>
-        </React.Fragment>
-      )}
-    </Grid>
-  )
+    )
+  }
 }
 
 export default AttentionAnswers

--- a/packages/dashboard/src/components/Answers/Answers.tsx
+++ b/packages/dashboard/src/components/Answers/Answers.tsx
@@ -2,8 +2,16 @@ import { Grid, Typography } from "@material-ui/core"
 import React from "react"
 import { Link } from "react-router-dom"
 import Answer from "./Answer"
+import PageSelector from "./PageSelector"
 
-const AttentionAnswers = ({ answers, quiz, showingAll }) => {
+const AttentionAnswers = ({
+  answers,
+  quiz,
+  showingAll,
+  currentPage,
+  totalPages,
+  onPageChange,
+}) => {
   return (
     <Grid
       container={true}
@@ -34,6 +42,14 @@ const AttentionAnswers = ({ answers, quiz, showingAll }) => {
         )}
       </Grid>
 
+      <Grid item={true} xs="auto">
+        <PageSelector
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={onPageChange}
+        />
+      </Grid>
+
       {answers.map((answer, idx) => {
         return (
           <Answer
@@ -45,6 +61,14 @@ const AttentionAnswers = ({ answers, quiz, showingAll }) => {
           />
         )
       })}
+
+      <Grid item={true} xs="auto">
+        <PageSelector
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={onPageChange}
+        />
+      </Grid>
     </Grid>
   )
 }

--- a/packages/dashboard/src/components/Answers/FilterOptions.tsx
+++ b/packages/dashboard/src/components/Answers/FilterOptions.tsx
@@ -2,7 +2,6 @@ import { Grid, Typography } from "@material-ui/core"
 import React from "react"
 
 const FilterBox = ({ numberOfAnswers }) => {
-  console.log("Number of answers: ", numberOfAnswers)
   return (
     <React.Fragment>
       <Grid

--- a/packages/dashboard/src/components/Answers/FilterOptions.tsx
+++ b/packages/dashboard/src/components/Answers/FilterOptions.tsx
@@ -2,6 +2,7 @@ import { Grid, Typography } from "@material-ui/core"
 import React from "react"
 
 const FilterBox = ({ numberOfAnswers }) => {
+  console.log("Number of answers: ", numberOfAnswers)
   return (
     <React.Fragment>
       <Grid

--- a/packages/dashboard/src/components/Answers/GeneralQuizStatistics.tsx
+++ b/packages/dashboard/src/components/Answers/GeneralQuizStatistics.tsx
@@ -21,8 +21,7 @@ class GeneralStatistics extends React.Component<any, any> {
         >
           <Grid item={true} xs={12}>
             <Typography variant="body1">
-              Answers requiring attention:{" "}
-              {this.props.counts.find(c => c.quizId === this.props.id).count}
+              Answers requiring attention: {this.props.numberOfAnswers}
             </Typography>
           </Grid>
 

--- a/packages/dashboard/src/components/Answers/GeneralQuizStatistics.tsx
+++ b/packages/dashboard/src/components/Answers/GeneralQuizStatistics.tsx
@@ -1,46 +1,56 @@
 import { Grid, Typography } from "@material-ui/core"
 import React from "react"
+import { connect } from "react-redux"
 
-const GeneralStatistics = ({ answers }) => {
-  return (
-    <React.Fragment>
-      <Grid
-        item={true}
-        xs={12}
-        style={{ marginBottom: "1.5em", textAlign: "center" }}
-      >
-        <Typography variant="title">QUIZ STATISTICS</Typography>
-      </Grid>
-
-      <Grid
-        container={true}
-        spacing={32}
-        style={{ backgroundColor: "#49C7FB" }}
-      >
-        <Grid item={true} xs={12}>
-          <Typography variant="body1">
-            Answers requiring attention: {answers.length}
-          </Typography>
+class GeneralStatistics extends React.Component<any, any> {
+  public render() {
+    return (
+      <React.Fragment>
+        <Grid
+          item={true}
+          xs={12}
+          style={{ marginBottom: "1.5em", textAlign: "center" }}
+        >
+          <Typography variant="title">QUIZ STATISTICS</Typography>
         </Grid>
 
-        <Grid item={true} xs={12}>
-          <Typography variant="body1">Of those:</Typography>
-          <ul>
-            <li>
-              <Grid item={true} xs={12}>
-                <Typography variant="body1">
-                  Waiting for peer review(s): {"-"}
-                </Typography>
-              </Grid>
-            </li>
-            <li>
-              <Typography variant="body1">Flagged as spam: {"-"}</Typography>
-            </li>
-          </ul>
+        <Grid
+          container={true}
+          spacing={32}
+          style={{ backgroundColor: "#49C7FB" }}
+        >
+          <Grid item={true} xs={12}>
+            <Typography variant="body1">
+              Answers requiring attention:{" "}
+              {this.props.counts.find(c => c.quizId === this.props.id).count}
+            </Typography>
+          </Grid>
+
+          <Grid item={true} xs={12}>
+            <Typography variant="body1">Of those:</Typography>
+            <ul>
+              <li>
+                <Grid item={true} xs={12}>
+                  <Typography variant="body1">
+                    Waiting for peer review(s): {"-"}
+                  </Typography>
+                </Grid>
+              </li>
+              <li>
+                <Typography variant="body1">Flagged as spam: {"-"}</Typography>
+              </li>
+            </ul>
+          </Grid>
         </Grid>
-      </Grid>
-    </React.Fragment>
-  )
+      </React.Fragment>
+    )
+  }
 }
 
-export default GeneralStatistics
+const mapStateToProps = (state: any) => {
+  return {
+    counts: state.answerCounts,
+  }
+}
+
+export default connect(mapStateToProps)(GeneralStatistics)

--- a/packages/dashboard/src/components/Answers/ItemAnswer.tsx
+++ b/packages/dashboard/src/components/Answers/ItemAnswer.tsx
@@ -101,13 +101,14 @@ const ItemAnswerContent = ({ answer, fullLength, type, item }) => {
       return (
         <React.Fragment>
           <Typography variant="body1">
-            Correct option{correctOptions.length > 0 ? "s" : ""} :
+            Correct option{correctOptions.length > 1 ? "s" : ""}
+            {": "}
             <span style={{ fontWeight: "bold" }}>
-              {correctOptions.map(opt => opt.title)}
+              {correctOptions.map(opt => opt.title).join(", ")}
             </span>
           </Typography>
           <Typography variant="body1">
-            Chosen answer:
+            Chosen answer{": "}
             <span style={{ color: chosen && chosen.correct ? "green" : "red" }}>
               {chosen ? chosen.title : ""}
             </span>

--- a/packages/dashboard/src/components/Answers/ItemAnswer.tsx
+++ b/packages/dashboard/src/components/Answers/ItemAnswer.tsx
@@ -6,9 +6,8 @@ const ItemAnswer = ({ answer, idx, quiz }) => {
     <Grid
       container={true}
       alignItems="flex-start"
-      style={{
-        marginLeft: ".5em",
-      }}
+      spacing={8}
+      style={{ paddingLeft: "1em" }}
     >
       {quiz.items.map((qItem, qIdx) => {
         const isFirst = qIdx === 0

--- a/packages/dashboard/src/components/Answers/ItemAnswer.tsx
+++ b/packages/dashboard/src/components/Answers/ItemAnswer.tsx
@@ -1,7 +1,7 @@
 import { Grid, Typography } from "@material-ui/core"
 import React from "react"
 
-const ItemAnswer = ({ answer, idx, quiz }) => {
+const ItemAnswer = ({ answer, idx, quiz, fullLength }) => {
   return (
     <Grid
       container={true}
@@ -40,6 +40,7 @@ const ItemAnswer = ({ answer, idx, quiz }) => {
                 type={qItem.type}
                 item={qItem}
                 answer={answer.itemAnswers.find(a => a.quizItemId === qItem.id)}
+                fullLength={fullLength}
               />
             </Grid>
 
@@ -58,7 +59,7 @@ const ItemAnswer = ({ answer, idx, quiz }) => {
   )
 }
 
-const ItemAnswerContent = ({ answer, type, item }) => {
+const ItemAnswerContent = ({ answer, fullLength, type, item }) => {
   if (!answer) {
     return (
       <Typography variant="button">
@@ -66,11 +67,21 @@ const ItemAnswerContent = ({ answer, type, item }) => {
       </Typography>
     )
   }
+
+  let textData = answer.textData
+
+  if (!fullLength && answer.textData && answer.textData.length > 1500) {
+    textData = answer.textData.substring(0, 1501) + "..."
+  }
+
   switch (type) {
     case "essay":
       return (
-        <Typography variant="body1" style={{ whiteSpace: "pre-wrap" }}>
-          {answer.textData}
+        <Typography
+          variant="body1"
+          style={{ whiteSpace: "pre-wrap", wordBreak: "break-word" }}
+        >
+          {textData}
         </Typography>
       )
     case "multiple-choice":
@@ -114,10 +125,10 @@ const ItemAnswerContent = ({ answer, type, item }) => {
             Answer:{" "}
             {answer.correct !== null ? (
               <span style={{ color: answer.correct ? "green" : "red" }}>
-                {answer.textData}
+                {textData}
               </span>
             ) : (
-              answer.textData
+              textData
             )}
           </Typography>
         </React.Fragment>
@@ -149,7 +160,18 @@ const ItemAnswerContent = ({ answer, type, item }) => {
           })}
         </React.Fragment>
       )
-
+    case "custom-frontend-accept-data":
+      return (
+        <React.Fragment>
+          <Typography variant="subtitle1">Stored data:</Typography>
+          <Typography
+            variant="body1"
+            style={{ whiteSpace: "pre-wrap", wordBreak: "break-word" }}
+          >
+            {textData}
+          </Typography>
+        </React.Fragment>
+      )
     default:
       return (
         <Typography variant="subtitle1">Unknown / unsupported type</Typography>

--- a/packages/dashboard/src/components/Answers/PageSelector.tsx
+++ b/packages/dashboard/src/components/Answers/PageSelector.tsx
@@ -15,91 +15,107 @@ import ChevronRight from "@material-ui/icons/ChevronRight"
 import React from "react"
 
 const PageSelector = ({
+  isAtBottom = false,
   changeResultsPerPage,
   currentPage,
   onPageChange,
   resultsPerPage,
   totalPages,
-}) => (
-  <Grid container={true} justify="space-between">
-    <Grid item={true} xs="auto">
-      <Grid
-        container={true}
-        spacing={0}
-        justify="flex-start"
-        alignContent="center"
-        alignItems="center"
-        style={{
-          backgroundColor: "silver",
-        }}
-      >
-        <PageButton icon={true} onClick={onPageChange(currentPage - 1)}>
-          <ChevronLeft fontSize="small" />
-        </PageButton>
+}) => {
+  const handlePageChange = isAtBottom
+    ? (n: number) => () => {
+        scrollTo({ left: 0, top: 0, behavior: "auto" })
+        onPageChange(n)()
+      }
+    : onPageChange
 
-        {currentPage > 2 && (
-          <PageButton onClick={onPageChange(1)}>1</PageButton>
-        )}
+  const handleResultsPerPageChange = isAtBottom
+    ? async (e: React.ChangeEvent<HTMLSelectElement>) => {
+        changeResultsPerPage(e, true)
+      }
+    : changeResultsPerPage
 
-        {currentPage > 3 && (
-          <Grid item={true} xs="auto">
-            <Typography variant="body1">...</Typography>
-          </Grid>
-        )}
-
-        {currentPage > 1 && (
-          <PageButton onClick={onPageChange(currentPage - 1)}>
-            {currentPage - 1}
+  return (
+    <Grid container={true} justify="space-between">
+      <Grid item={true} xs="auto">
+        <Grid
+          container={true}
+          spacing={0}
+          justify="flex-start"
+          alignContent="center"
+          alignItems="center"
+          style={{
+            backgroundColor: "silver",
+          }}
+        >
+          <PageButton icon={true} onClick={handlePageChange(currentPage - 1)}>
+            <ChevronLeft fontSize="small" />
           </PageButton>
-        )}
 
-        <PageButton current={true}>{currentPage}</PageButton>
+          {currentPage > 2 && (
+            <PageButton onClick={handlePageChange(1)}>1</PageButton>
+          )}
 
-        {totalPages - currentPage > 0 && (
-          <PageButton onClick={onPageChange(currentPage + 1)}>
-            {currentPage + 1}
+          {currentPage > 3 && (
+            <Grid item={true} xs="auto">
+              <Typography variant="body1">...</Typography>
+            </Grid>
+          )}
+
+          {currentPage > 1 && (
+            <PageButton onClick={handlePageChange(currentPage - 1)}>
+              {currentPage - 1}
+            </PageButton>
+          )}
+
+          <PageButton current={true}>{currentPage}</PageButton>
+
+          {totalPages - currentPage > 0 && (
+            <PageButton onClick={handlePageChange(currentPage + 1)}>
+              {currentPage + 1}
+            </PageButton>
+          )}
+
+          {totalPages - currentPage > 2 && (
+            <Grid xs="auto" item={true}>
+              <Typography variant="body1">...</Typography>
+            </Grid>
+          )}
+
+          {totalPages - currentPage > 1 && (
+            <PageButton onClick={handlePageChange(totalPages)}>
+              {totalPages}
+            </PageButton>
+          )}
+
+          <PageButton icon={true} onClick={handlePageChange(currentPage + 1)}>
+            <ChevronRight fontSize="small" />
           </PageButton>
-        )}
+        </Grid>
+      </Grid>
 
-        {totalPages - currentPage > 2 && (
-          <Grid xs="auto" item={true}>
-            <Typography variant="body1">...</Typography>
-          </Grid>
-        )}
-
-        {totalPages - currentPage > 1 && (
-          <PageButton onClick={onPageChange(totalPages)}>
-            {totalPages}
-          </PageButton>
-        )}
-
-        <PageButton icon={true} onClick={onPageChange(currentPage + 1)}>
-          <ChevronRight fontSize="small" />
-        </PageButton>
+      <Grid item={true} xs="auto">
+        <FormControl>
+          <FormControlLabel
+            label="Answers per page"
+            labelPlacement="bottom"
+            control={
+              <Select
+                value={resultsPerPage}
+                onChange={handleResultsPerPageChange}
+                name="resultsPerPage"
+              >
+                <MenuItem value={10}>10</MenuItem>
+                <MenuItem value={25}>25</MenuItem>
+                <MenuItem value={50}>50</MenuItem>
+              </Select>
+            }
+          />
+        </FormControl>
       </Grid>
     </Grid>
-
-    <Grid item={true} xs="auto">
-      <FormControl>
-        <FormControlLabel
-          label="Answers per page"
-          labelPlacement="bottom"
-          control={
-            <Select
-              value={resultsPerPage}
-              onChange={changeResultsPerPage}
-              name="resultsPerPage"
-            >
-              <MenuItem value={10}>10</MenuItem>
-              <MenuItem value={25}>25</MenuItem>
-              <MenuItem value={50}>50</MenuItem>
-            </Select>
-          }
-        />
-      </FormControl>
-    </Grid>
-  </Grid>
-)
+  )
+}
 
 const PageButton = props => {
   if (props.current) {

--- a/packages/dashboard/src/components/Answers/PageSelector.tsx
+++ b/packages/dashboard/src/components/Answers/PageSelector.tsx
@@ -146,7 +146,12 @@ const PageButton = props => {
       {props.icon ? (
         <IconButton onClick={props.onClick}>{props.children}</IconButton>
       ) : (
-        <Button size="small" onClick={props.onClick}>
+        <Button
+          size="small"
+          onClick={props.onClick}
+          disableRipple={true}
+          disableTouchRipple={true}
+        >
           {props.children}
         </Button>
       )}

--- a/packages/dashboard/src/components/Answers/PageSelector.tsx
+++ b/packages/dashboard/src/components/Answers/PageSelector.tsx
@@ -20,7 +20,11 @@ const PageSelector = ({ currentPage, totalPages, onPageChange }) => (
 
     {currentPage > 2 && <PageButton onClick={onPageChange(1)}>1</PageButton>}
 
-    {currentPage > 3 && <Typography variant="body1">...</Typography>}
+    {currentPage > 3 && (
+      <Grid item={true} xs="auto">
+        <Typography variant="body1">...</Typography>
+      </Grid>
+    )}
 
     {currentPage > 1 && (
       <PageButton onClick={onPageChange(currentPage - 1)}>
@@ -37,18 +41,18 @@ const PageSelector = ({ currentPage, totalPages, onPageChange }) => (
     )}
 
     {totalPages - currentPage > 2 && (
-      <Typography variant="body1">...</Typography>
+      <Grid xs="auto" item={true}>
+        <Typography variant="body1">...</Typography>
+      </Grid>
     )}
 
     {totalPages - currentPage > 1 && (
       <PageButton onClick={onPageChange(totalPages)}>{totalPages}</PageButton>
     )}
 
-    {totalPages - currentPage > 0 && (
-      <PageButton icon={true} onClick={onPageChange(currentPage + 1)}>
-        <ChevronRight fontSize="small" />
-      </PageButton>
-    )}
+    <PageButton icon={true} onClick={onPageChange(currentPage + 1)}>
+      <ChevronRight fontSize="small" />
+    </PageButton>
   </Grid>
 )
 
@@ -66,17 +70,11 @@ const PageButton = props => {
   }
 
   return (
-    <Grid
-      item={true}
-      xs="auto"
-      alignContent="stretch"
-      alignItems="stretch"
-      justify="center"
-    >
+    <Grid item={true} xs="auto">
       {props.icon ? (
         <IconButton onClick={props.onClick}>{props.children}</IconButton>
       ) : (
-        <Button fullWidth={true} size="small" onClick={props.onClick}>
+        <Button size="small" onClick={props.onClick}>
           {props.children}
         </Button>
       )}

--- a/packages/dashboard/src/components/Answers/PageSelector.tsx
+++ b/packages/dashboard/src/components/Answers/PageSelector.tsx
@@ -1,0 +1,77 @@
+import { Button, Grid, IconButton, Typography } from "@material-ui/core"
+import ChevronLeft from "@material-ui/icons/ChevronLeft"
+import ChevronRight from "@material-ui/icons/ChevronRight"
+import FirstPage from "@material-ui/icons/FirstPage"
+import LastPage from "@material-ui/icons/LastPage"
+import React from "react"
+
+const PageSelector = ({ currentPage, totalPages, onPageChange }) => (
+  <Grid
+    container={true}
+    spacing={0}
+    justify="flex-start"
+    style={{
+      backgroundColor: "silver",
+    }}
+  >
+    <PageButton icon={true} onClick={onPageChange(1)}>
+      <FirstPage fontSize="small" />
+    </PageButton>
+
+    <PageButton icon={true} onClick={onPageChange(currentPage - 1)}>
+      <ChevronLeft fontSize="small" />
+    </PageButton>
+
+    {currentPage > 2 && <Typography variant="body1">...</Typography>}
+
+    {currentPage > 1 && (
+      <PageButton onClick={onPageChange(currentPage - 1)}>
+        {currentPage - 1}
+      </PageButton>
+    )}
+
+    <PageButton current={true}>{currentPage}</PageButton>
+
+    <PageButton onClick={onPageChange(currentPage + 1)}>
+      {currentPage + 1}
+    </PageButton>
+
+    {totalPages - currentPage > 2 && (
+      <Typography variant="body1">...</Typography>
+    )}
+
+    {totalPages - currentPage > 1 && (
+      <PageButton onClick={onPageChange(totalPages)}>{totalPages}</PageButton>
+    )}
+
+    <PageButton icon={true} onClick={onPageChange(currentPage + 1)}>
+      <ChevronRight fontSize="small" />
+    </PageButton>
+
+    <PageButton icon={true} onClick={onPageChange(totalPages)}>
+      <LastPage fontSize="small" />
+    </PageButton>
+  </Grid>
+)
+
+const PageButton = props => {
+  if (props.current) {
+    return (
+      <Button disabled={true} style={{ backgroundColor: "lightgray" }}>
+        {props.children}
+      </Button>
+    )
+  }
+
+  return (
+    <Grid item={true} xs="auto">
+      {props.icon ? (
+        <IconButton onClick={props.onClick}>{props.children}</IconButton>
+      ) : (
+        <Button onClick={props.onClick}>{props.children}</Button>
+      )}
+    </Grid>
+  )
+}
+
+export default PageSelector

--- a/packages/dashboard/src/components/Answers/PageSelector.tsx
+++ b/packages/dashboard/src/components/Answers/PageSelector.tsx
@@ -16,6 +16,7 @@ import React from "react"
 
 const PageSelector = ({
   isAtBottom = false,
+  upRef,
   changeResultsPerPage,
   currentPage,
   onPageChange,
@@ -24,7 +25,17 @@ const PageSelector = ({
 }) => {
   const handlePageChange = isAtBottom
     ? (n: number) => () => {
-        scrollTo({ left: 0, top: 0, behavior: "auto" })
+        if (!upRef || !upRef.current) {
+          onPageChange(n)()
+          return
+        }
+
+        // -100 a quick fix for the navbar taking space
+        scrollTo({
+          left: 0,
+          top: upRef.current.offsetTop - 100,
+          behavior: "auto",
+        })
         onPageChange(n)()
       }
     : onPageChange

--- a/packages/dashboard/src/components/Answers/PageSelector.tsx
+++ b/packages/dashboard/src/components/Answers/PageSelector.tsx
@@ -1,58 +1,103 @@
-import { Button, Grid, IconButton, Typography } from "@material-ui/core"
+import {
+  Button,
+  FormControl,
+  FormControlLabel,
+  FormHelperText,
+  Grid,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Select,
+  Typography,
+} from "@material-ui/core"
 import ChevronLeft from "@material-ui/icons/ChevronLeft"
 import ChevronRight from "@material-ui/icons/ChevronRight"
 import React from "react"
 
-const PageSelector = ({ currentPage, totalPages, onPageChange }) => (
-  <Grid
-    container={true}
-    spacing={0}
-    justify="flex-start"
-    alignContent="center"
-    alignItems="center"
-    style={{
-      backgroundColor: "silver",
-    }}
-  >
-    <PageButton icon={true} onClick={onPageChange(currentPage - 1)}>
-      <ChevronLeft fontSize="small" />
-    </PageButton>
+const PageSelector = ({
+  changeResultsPerPage,
+  currentPage,
+  onPageChange,
+  resultsPerPage,
+  totalPages,
+}) => (
+  <Grid container={true} justify="space-between">
+    <Grid item={true} xs="auto">
+      <Grid
+        container={true}
+        spacing={0}
+        justify="flex-start"
+        alignContent="center"
+        alignItems="center"
+        style={{
+          backgroundColor: "silver",
+        }}
+      >
+        <PageButton icon={true} onClick={onPageChange(currentPage - 1)}>
+          <ChevronLeft fontSize="small" />
+        </PageButton>
 
-    {currentPage > 2 && <PageButton onClick={onPageChange(1)}>1</PageButton>}
+        {currentPage > 2 && (
+          <PageButton onClick={onPageChange(1)}>1</PageButton>
+        )}
 
-    {currentPage > 3 && (
-      <Grid item={true} xs="auto">
-        <Typography variant="body1">...</Typography>
+        {currentPage > 3 && (
+          <Grid item={true} xs="auto">
+            <Typography variant="body1">...</Typography>
+          </Grid>
+        )}
+
+        {currentPage > 1 && (
+          <PageButton onClick={onPageChange(currentPage - 1)}>
+            {currentPage - 1}
+          </PageButton>
+        )}
+
+        <PageButton current={true}>{currentPage}</PageButton>
+
+        {totalPages - currentPage > 0 && (
+          <PageButton onClick={onPageChange(currentPage + 1)}>
+            {currentPage + 1}
+          </PageButton>
+        )}
+
+        {totalPages - currentPage > 2 && (
+          <Grid xs="auto" item={true}>
+            <Typography variant="body1">...</Typography>
+          </Grid>
+        )}
+
+        {totalPages - currentPage > 1 && (
+          <PageButton onClick={onPageChange(totalPages)}>
+            {totalPages}
+          </PageButton>
+        )}
+
+        <PageButton icon={true} onClick={onPageChange(currentPage + 1)}>
+          <ChevronRight fontSize="small" />
+        </PageButton>
       </Grid>
-    )}
+    </Grid>
 
-    {currentPage > 1 && (
-      <PageButton onClick={onPageChange(currentPage - 1)}>
-        {currentPage - 1}
-      </PageButton>
-    )}
-
-    <PageButton current={true}>{currentPage}</PageButton>
-
-    {totalPages - currentPage > 0 && (
-      <PageButton onClick={onPageChange(currentPage + 1)}>
-        {currentPage + 1}
-      </PageButton>
-    )}
-
-    {totalPages - currentPage > 2 && (
-      <Grid xs="auto" item={true}>
-        <Typography variant="body1">...</Typography>
-      </Grid>
-    )}
-
-    {totalPages - currentPage > 1 && (
-      <PageButton onClick={onPageChange(totalPages)}>{totalPages}</PageButton>
-    )}
-
-    <PageButton icon={true} onClick={onPageChange(currentPage + 1)}>
-      <ChevronRight fontSize="small" />
-    </PageButton>
+    <Grid item={true} xs="auto">
+      <FormControl>
+        <FormControlLabel
+          label="Answers per page"
+          labelPlacement="bottom"
+          control={
+            <Select
+              value={resultsPerPage}
+              onChange={changeResultsPerPage}
+              name="resultsPerPage"
+            >
+              <MenuItem value={10}>10</MenuItem>
+              <MenuItem value={25}>25</MenuItem>
+              <MenuItem value={50}>50</MenuItem>
+            </Select>
+          }
+        />
+      </FormControl>
+    </Grid>
   </Grid>
 )
 

--- a/packages/dashboard/src/components/Answers/PageSelector.tsx
+++ b/packages/dashboard/src/components/Answers/PageSelector.tsx
@@ -1,8 +1,6 @@
 import { Button, Grid, IconButton, Typography } from "@material-ui/core"
 import ChevronLeft from "@material-ui/icons/ChevronLeft"
 import ChevronRight from "@material-ui/icons/ChevronRight"
-import FirstPage from "@material-ui/icons/FirstPage"
-import LastPage from "@material-ui/icons/LastPage"
 import React from "react"
 
 const PageSelector = ({ currentPage, totalPages, onPageChange }) => (
@@ -10,19 +8,19 @@ const PageSelector = ({ currentPage, totalPages, onPageChange }) => (
     container={true}
     spacing={0}
     justify="flex-start"
+    alignContent="center"
+    alignItems="center"
     style={{
       backgroundColor: "silver",
     }}
   >
-    <PageButton icon={true} onClick={onPageChange(1)}>
-      <FirstPage fontSize="small" />
-    </PageButton>
-
     <PageButton icon={true} onClick={onPageChange(currentPage - 1)}>
       <ChevronLeft fontSize="small" />
     </PageButton>
 
-    {currentPage > 2 && <Typography variant="body1">...</Typography>}
+    {currentPage > 2 && <PageButton onClick={onPageChange(1)}>1</PageButton>}
+
+    {currentPage > 3 && <Typography variant="body1">...</Typography>}
 
     {currentPage > 1 && (
       <PageButton onClick={onPageChange(currentPage - 1)}>
@@ -32,9 +30,11 @@ const PageSelector = ({ currentPage, totalPages, onPageChange }) => (
 
     <PageButton current={true}>{currentPage}</PageButton>
 
-    <PageButton onClick={onPageChange(currentPage + 1)}>
-      {currentPage + 1}
-    </PageButton>
+    {totalPages - currentPage > 0 && (
+      <PageButton onClick={onPageChange(currentPage + 1)}>
+        {currentPage + 1}
+      </PageButton>
+    )}
 
     {totalPages - currentPage > 2 && (
       <Typography variant="body1">...</Typography>
@@ -44,31 +44,41 @@ const PageSelector = ({ currentPage, totalPages, onPageChange }) => (
       <PageButton onClick={onPageChange(totalPages)}>{totalPages}</PageButton>
     )}
 
-    <PageButton icon={true} onClick={onPageChange(currentPage + 1)}>
-      <ChevronRight fontSize="small" />
-    </PageButton>
-
-    <PageButton icon={true} onClick={onPageChange(totalPages)}>
-      <LastPage fontSize="small" />
-    </PageButton>
+    {totalPages - currentPage > 0 && (
+      <PageButton icon={true} onClick={onPageChange(currentPage + 1)}>
+        <ChevronRight fontSize="small" />
+      </PageButton>
+    )}
   </Grid>
 )
 
 const PageButton = props => {
   if (props.current) {
     return (
-      <Button disabled={true} style={{ backgroundColor: "lightgray" }}>
+      <Button
+        size="small"
+        disabled={true}
+        style={{ backgroundColor: "lightgray" }}
+      >
         {props.children}
       </Button>
     )
   }
 
   return (
-    <Grid item={true} xs="auto">
+    <Grid
+      item={true}
+      xs="auto"
+      alignContent="stretch"
+      alignItems="stretch"
+      justify="center"
+    >
       {props.icon ? (
         <IconButton onClick={props.onClick}>{props.children}</IconButton>
       ) : (
-        <Button onClick={props.onClick}>{props.children}</Button>
+        <Button fullWidth={true} size="small" onClick={props.onClick}>
+          {props.children}
+        </Button>
       )}
     </Grid>
   )

--- a/packages/dashboard/src/components/Answers/PeerReviewsModal.tsx
+++ b/packages/dashboard/src/components/Answers/PeerReviewsModal.tsx
@@ -167,7 +167,7 @@ const PeerReviewQuestionAnswer = ({ type, questionAnswer, title }) => {
     )
   } else if (type === "grade") {
     return (
-      <FormControl>
+      <FormControl fullWidth={true}>
         <FormLabel>{title}</FormLabel>
         <RadioGroup value={`${questionAnswer.value}`} row={true}>
           {[1, 2, 3, 4, 5].map(n => {

--- a/packages/dashboard/src/components/Answers/PeerReviewsModal.tsx
+++ b/packages/dashboard/src/components/Answers/PeerReviewsModal.tsx
@@ -192,7 +192,8 @@ const PeerReviewQuestionAnswer = ({ type, questionAnswer, title }) => {
 const mapStateToProps = state => {
   return {
     answers: state.answers,
-    quizzes: state.quizzes,
+    quizzes: state.quizzes.find(qi => qi.courseId === state.filter.course)
+      .quizzes,
   }
 }
 

--- a/packages/dashboard/src/components/Answers/QuizStatistics.tsx
+++ b/packages/dashboard/src/components/Answers/QuizStatistics.tsx
@@ -143,22 +143,31 @@ class QuizStatistics extends React.Component<any, any> {
                   </Typography>
                 </Grid>
 
-                <Grid item={true}>
+                <Grid item={true} xs={12} md={10} lg={8}>
                   <Paper
+                    square={true}
                     style={{
-                      padding: "1em",
+                      padding: "1.5em",
                     }}
                   >
-                    <Typography variant="h5">{quiz.texts[0].title}</Typography>
-                    <Typography
-                      variant="body1"
-                      style={{
-                        whiteSpace: "pre-wrap",
-                        wordBreak: "break-word",
-                      }}
-                    >
-                      {quiz.texts[0].body}
-                    </Typography>
+                    <Grid container={true} justify="center" spacing={24}>
+                      <Grid item={true} xs="auto">
+                        <Typography variant="h5">
+                          {quiz.texts[0].title}
+                        </Typography>
+                      </Grid>
+                      <Grid>
+                        <Typography
+                          variant="body1"
+                          style={{
+                            whiteSpace: "pre-wrap",
+                            wordBreak: "break-word",
+                          }}
+                        >
+                          {quiz.texts[0].body}
+                        </Typography>
+                      </Grid>
+                    </Grid>
                   </Paper>
                 </Grid>
               </Grid>
@@ -250,7 +259,6 @@ class QuizStatistics extends React.Component<any, any> {
   }
 
   public handlePageChange = (newPage: number) => async () => {
-    console.log("Beginning page change")
     if (newPage < 1) {
       newPage = 1
     }

--- a/packages/dashboard/src/components/Answers/QuizStatistics.tsx
+++ b/packages/dashboard/src/components/Answers/QuizStatistics.tsx
@@ -2,6 +2,7 @@ import { CircularProgress, Grid, Typography } from "@material-ui/core"
 import queryString from "query-string"
 import React from "react"
 import { connect } from "react-redux"
+import { setAllAnswersCount } from "../../store/answerCounts/actions"
 import {
   setAllAnswers,
   setAttentionRequiringAnswers,
@@ -19,6 +20,8 @@ class QuizStatistics extends React.Component<any, any> {
     this.state = {
       initialized: false,
       showingAll: false,
+      displayingPage: 1,
+      answersPerPage: 10,
     }
   }
 
@@ -28,12 +31,19 @@ class QuizStatistics extends React.Component<any, any> {
 
     if (this.state.showingAll !== showing) {
       if (showing) {
-        this.props.setAllAnswers(this.props.match.params.id)
+        //  this.props.setAllAnswersCount(this.props.match.params.id)
+        this.props.setAllAnswers(this.props.match.params.id, 1, 10)
       } else {
-        this.props.setAttentionRequiringAnswers(this.props.match.params.id)
+        this.props.setAttentionRequiringAnswers(
+          this.props.match.params.id,
+          1,
+          10,
+        )
       }
       this.setState({
         showingAll: showing,
+        displayingPage: 1,
+        answersPerPage: 10,
       })
     }
   }
@@ -46,9 +56,18 @@ class QuizStatistics extends React.Component<any, any> {
     const showing = queryParams.all && queryParams.all === "true"
 
     if (showing) {
-      this.props.setAllAnswers(this.props.match.params.id)
+      // this.props.setAllAnswersCount(this.props.match.params.id)
+      this.props.setAllAnswers(
+        this.props.match.params.id,
+        this.state.displayingPage,
+        this.state.answersPerPage,
+      )
     } else {
-      this.props.setAttentionRequiringAnswers(this.props.match.params.id)
+      this.props.setAttentionRequiringAnswers(
+        this.props.match.params.id,
+        this.state.displayingPage,
+        this.state.answersPerPage,
+      )
     }
     this.setState({
       showingAll: showing,
@@ -102,10 +121,15 @@ class QuizStatistics extends React.Component<any, any> {
                 >
                   {this.state.showingAll ? (
                     <FilterOptions
-                      numberOfAnswers={this.props.answers.length}
+                      numberOfAnswers={
+                        this.props.answerCounts.find(
+                          countInfo =>
+                            countInfo.quizId === this.props.match.params.id,
+                        ).count
+                      }
                     />
                   ) : (
-                    <GeneralQuizStatistics answers={this.props.answers} />
+                    <GeneralQuizStatistics id={this.props.match.params.id} />
                   )}
                 </Grid>
 
@@ -131,6 +155,7 @@ class QuizStatistics extends React.Component<any, any> {
 
 const mapStateToProps = (state: any) => {
   return {
+    answerCounts: state.answerCounts,
     answers: state.answers,
     quizzes: state.quizzes,
     courses: state.courses,
@@ -142,6 +167,7 @@ export default connect(
   mapStateToProps,
   {
     setAllAnswers,
+    setAllAnswersCount,
     setAnswerStatistics,
     setAttentionRequiringAnswers,
     setCourse,

--- a/packages/dashboard/src/components/Answers/QuizStatistics.tsx
+++ b/packages/dashboard/src/components/Answers/QuizStatistics.tsx
@@ -90,9 +90,12 @@ class QuizStatistics extends React.Component<any, any> {
       ci => ci.quizId === this.props.match.params.id,
     )
 
-    const totalNumberOfResults = this.state.showingAll
-      ? countInfo.totalCount
-      : countInfo.count
+    let totalNumberOfResults = 0
+    if (countInfo) {
+      totalNumberOfResults = this.state.showingAll
+        ? countInfo.totalCount
+        : countInfo.count
+    }
 
     return (
       <Grid container={true} justify="center" alignItems="center" spacing={16}>
@@ -131,7 +134,9 @@ class QuizStatistics extends React.Component<any, any> {
                   {this.state.showingAll ? (
                     <FilterOptions numberOfAnswers={totalNumberOfResults} />
                   ) : (
-                    <GeneralQuizStatistics id={this.props.match.params.id} />
+                    <GeneralQuizStatistics
+                      numberOfAnswers={totalNumberOfResults}
+                    />
                   )}
                 </Grid>
 
@@ -162,6 +167,18 @@ class QuizStatistics extends React.Component<any, any> {
   public handlePageChange = (newPage: number) => () => {
     if (newPage < 1) {
       newPage = 1
+    }
+
+    const countInfo = this.props.answerCounts.find(
+      ci => ci.quizId === this.props.match.params.id,
+    )
+    const pages = Math.ceil(
+      (this.state.showingAll ? countInfo.totalCount : countInfo.count) /
+        this.state.answersPerPage,
+    )
+
+    if (newPage > pages) {
+      newPage = pages
     }
     this.state.showingAll
       ? this.props.setAllAnswers(

--- a/packages/dashboard/src/components/Answers/QuizStatistics.tsx
+++ b/packages/dashboard/src/components/Answers/QuizStatistics.tsx
@@ -22,6 +22,7 @@ class QuizStatistics extends React.Component<any, any> {
       showingAll: false,
       displayingPage: 1,
       answersPerPage: 10,
+      scrollDownAfterUpdate: false,
     }
   }
 
@@ -45,6 +46,14 @@ class QuizStatistics extends React.Component<any, any> {
         displayingPage: 1,
         answersPerPage: 10,
       })
+    }
+
+    if (
+      this.state.scrollDownAfterUpdate &&
+      this.state.answersPerPage === this.props.answers.length
+    ) {
+      this.setState({ scrollDownAfterUpdate: false })
+      scrollTo({ left: 0, top: document.body.scrollHeight, behavior: "auto" })
     }
   }
 
@@ -170,8 +179,15 @@ class QuizStatistics extends React.Component<any, any> {
     )
   }
 
-  public handleChangeAnswersPerPage = e => {
-    const newLengthOfPage = e.target.value
+  public handleChangeAnswersPerPage = async (
+    e: React.ChangeEvent<HTMLSelectElement>,
+    finishAtBottom: boolean = false,
+  ) => {
+    const newLengthOfPage = Number(e.target.value)
+    if (newLengthOfPage === this.state.answersPerPage) {
+      return
+    }
+
     const indexOfFirstOnPage =
       this.state.answersPerPage * (this.state.displayingPage - 1) + 1
     const newDisplayingPage = Math.ceil(indexOfFirstOnPage / newLengthOfPage)
@@ -179,9 +195,9 @@ class QuizStatistics extends React.Component<any, any> {
     this.setState({
       answersPerPage: newLengthOfPage,
       displayingPage: newDisplayingPage,
+      scrollDownAfterUpdate: finishAtBottom,
     })
-
-    this.state.showingAll
+    ;(await this.state.showingAll)
       ? this.props.setAllAnswers(
           this.props.filter.quiz,
           newDisplayingPage,

--- a/packages/dashboard/src/components/Answers/QuizStatistics.tsx
+++ b/packages/dashboard/src/components/Answers/QuizStatistics.tsx
@@ -112,7 +112,7 @@ class QuizStatistics extends React.Component<any, any> {
 
     return (
       <Grid container={true} justify="center" alignItems="center" spacing={16}>
-        <Grid item={true} xs={10}>
+        <Grid item={true} xs={12} md={10}>
           <Grid
             container={true}
             direction="row-reverse"
@@ -120,16 +120,38 @@ class QuizStatistics extends React.Component<any, any> {
             alignItems="stretch"
             spacing={16}
           >
-            <Grid item={true} xs="auto">
-              <Typography variant="title">
-                {currentCourse &&
-                  currentCourse.texts[0] &&
-                  currentCourse.texts[0].title.toUpperCase()}
-              </Typography>
-              <Typography variant="subtitle1">
-                Part {quiz.part} section {quiz.section}
-              </Typography>
-              <Typography variant="subtitle1">{quiz.texts[0].title}</Typography>
+            <Grid item={true} xs={12}>
+              <Grid
+                container={true}
+                justify="center"
+                direction="column"
+                alignContent="center"
+                alignItems="center"
+              >
+                <Grid item={true}>
+                  <Typography variant="title">
+                    {currentCourse &&
+                      currentCourse.texts[0] &&
+                      currentCourse.texts[0].title.toUpperCase()}
+                  </Typography>
+                </Grid>
+
+                <Grid item={true}>
+                  <Typography variant="subtitle1">
+                    Part {quiz.part} section {quiz.section}
+                  </Typography>
+                </Grid>
+
+                <Grid item={true}>
+                  <Typography variant="subheading">
+                    {quiz.texts[0].title}
+                  </Typography>
+                </Grid>
+
+                <Grid item={true}>
+                  <Typography variant="body1">{quiz.texts[0].body}</Typography>
+                </Grid>
+              </Grid>
             </Grid>
 
             <LanguageBar />
@@ -183,6 +205,10 @@ class QuizStatistics extends React.Component<any, any> {
     e: React.ChangeEvent<HTMLSelectElement>,
     finishAtBottom: boolean = false,
   ) => {
+    if (typeof finishAtBottom !== "boolean") {
+      finishAtBottom = false
+    }
+
     const newLengthOfPage = Number(e.target.value)
     if (newLengthOfPage === this.state.answersPerPage) {
       return
@@ -195,9 +221,11 @@ class QuizStatistics extends React.Component<any, any> {
     this.setState({
       answersPerPage: newLengthOfPage,
       displayingPage: newDisplayingPage,
-      scrollDownAfterUpdate: finishAtBottom,
+      scrollDownAfterUpdate:
+        finishAtBottom && newLengthOfPage > this.state.answersPerPage,
     })
-    ;(await this.state.showingAll)
+
+    this.state.showingAll
       ? this.props.setAllAnswers(
           this.props.filter.quiz,
           newDisplayingPage,

--- a/packages/dashboard/src/components/Answers/QuizStatistics.tsx
+++ b/packages/dashboard/src/components/Answers/QuizStatistics.tsx
@@ -85,6 +85,15 @@ class QuizStatistics extends React.Component<any, any> {
     if (!quiz) {
       return <p />
     }
+
+    const countInfo = this.props.answerCounts.find(
+      ci => ci.quizId === this.props.match.params.id,
+    )
+
+    const totalNumberOfResults = this.state.showingAll
+      ? countInfo.totalCount
+      : countInfo.count
+
     return (
       <Grid container={true} justify="center" alignItems="center" spacing={16}>
         <Grid item={true} xs={10}>
@@ -120,14 +129,7 @@ class QuizStatistics extends React.Component<any, any> {
                   style={{ marginBottom: "1em" }}
                 >
                   {this.state.showingAll ? (
-                    <FilterOptions
-                      numberOfAnswers={
-                        this.props.answerCounts.find(
-                          countInfo =>
-                            countInfo.quizId === this.props.match.params.id,
-                        ).totalCount
-                      }
-                    />
+                    <FilterOptions numberOfAnswers={totalNumberOfResults} />
                   ) : (
                     <GeneralQuizStatistics id={this.props.match.params.id} />
                   )}
@@ -138,6 +140,11 @@ class QuizStatistics extends React.Component<any, any> {
                     answers={this.props.answers}
                     quiz={quiz}
                     showingAll={this.state.showingAll}
+                    currentPage={this.state.displayingPage}
+                    totalPages={Math.ceil(
+                      totalNumberOfResults / this.state.answersPerPage,
+                    )}
+                    onPageChange={this.handlePageChange}
                   />
                 </Grid>
               </React.Fragment>
@@ -150,6 +157,27 @@ class QuizStatistics extends React.Component<any, any> {
         </Grid>
       </Grid>
     )
+  }
+
+  public handlePageChange = (newPage: number) => () => {
+    if (newPage < 1) {
+      newPage = 1
+    }
+    this.state.showingAll
+      ? this.props.setAllAnswers(
+          this.props.filter.quiz,
+          newPage,
+          this.state.answersPerPage,
+        )
+      : this.props.setAttentionRequiringAnswers(
+          this.props.filter.quiz,
+          newPage,
+          this.state.answersPerPage,
+        )
+
+    this.setState({
+      displayingPage: newPage,
+    })
   }
 }
 

--- a/packages/dashboard/src/components/Answers/QuizStatistics.tsx
+++ b/packages/dashboard/src/components/Answers/QuizStatistics.tsx
@@ -31,8 +31,8 @@ class QuizStatistics extends React.Component<any, any> {
 
     if (this.state.showingAll !== showing) {
       if (showing) {
-        //  this.props.setAllAnswersCount(this.props.match.params.id)
         this.props.setAllAnswers(this.props.match.params.id, 1, 10)
+        this.props.setAllAnswersCount(this.props.match.params.id)
       } else {
         this.props.setAttentionRequiringAnswers(
           this.props.match.params.id,
@@ -56,12 +56,12 @@ class QuizStatistics extends React.Component<any, any> {
     const showing = queryParams.all && queryParams.all === "true"
 
     if (showing) {
-      // this.props.setAllAnswersCount(this.props.match.params.id)
       this.props.setAllAnswers(
         this.props.match.params.id,
         this.state.displayingPage,
         this.state.answersPerPage,
       )
+      this.props.setAllAnswersCount(this.props.match.params.id)
     } else {
       this.props.setAttentionRequiringAnswers(
         this.props.match.params.id,
@@ -125,7 +125,7 @@ class QuizStatistics extends React.Component<any, any> {
                         this.props.answerCounts.find(
                           countInfo =>
                             countInfo.quizId === this.props.match.params.id,
-                        ).count
+                        ).totalCount
                       }
                     />
                   ) : (

--- a/packages/dashboard/src/components/Answers/QuizStatistics.tsx
+++ b/packages/dashboard/src/components/Answers/QuizStatistics.tsx
@@ -154,6 +154,8 @@ class QuizStatistics extends React.Component<any, any> {
                       totalNumberOfResults / this.state.answersPerPage,
                     )}
                     onPageChange={this.handlePageChange}
+                    resultsPerPage={this.state.answersPerPage}
+                    changeResultsPerPage={this.handleChangeAnswersPerPage}
                   />
                 </Grid>
               </React.Fragment>
@@ -166,6 +168,30 @@ class QuizStatistics extends React.Component<any, any> {
         </Grid>
       </Grid>
     )
+  }
+
+  public handleChangeAnswersPerPage = e => {
+    const newLengthOfPage = e.target.value
+    const indexOfFirstOnPage =
+      this.state.answersPerPage * (this.state.displayingPage - 1) + 1
+    const newDisplayingPage = Math.ceil(indexOfFirstOnPage / newLengthOfPage)
+
+    this.setState({
+      answersPerPage: newLengthOfPage,
+      displayingPage: newDisplayingPage,
+    })
+
+    this.state.showingAll
+      ? this.props.setAllAnswers(
+          this.props.filter.quiz,
+          newDisplayingPage,
+          newLengthOfPage,
+        )
+      : this.props.setAttentionRequiringAnswers(
+          this.props.filter.quiz,
+          newDisplayingPage,
+          newLengthOfPage,
+        )
   }
 
   public handlePageChange = (newPage: number) => () => {

--- a/packages/dashboard/src/components/Answers/QuizStatistics.tsx
+++ b/packages/dashboard/src/components/Answers/QuizStatistics.tsx
@@ -71,6 +71,7 @@ class QuizStatistics extends React.Component<any, any> {
     }
     this.setState({
       showingAll: showing,
+      initialized: true,
     })
   }
 

--- a/packages/dashboard/src/components/Answers/QuizStatistics.tsx
+++ b/packages/dashboard/src/components/Answers/QuizStatistics.tsx
@@ -23,6 +23,7 @@ class QuizStatistics extends React.Component<any, any> {
       displayingPage: 1,
       answersPerPage: 10,
       scrollDownAfterUpdate: false,
+      waitingForNewAnswers: false,
     }
   }
 
@@ -177,6 +178,7 @@ class QuizStatistics extends React.Component<any, any> {
 
                 <Grid item={true} xs={12} md={8}>
                   <Answers
+                    inWaitingState={this.state.waitingForNewAnswers}
                     answers={this.props.answers}
                     quiz={quiz}
                     showingAll={this.state.showingAll}
@@ -238,7 +240,8 @@ class QuizStatistics extends React.Component<any, any> {
         )
   }
 
-  public handlePageChange = (newPage: number) => () => {
+  public handlePageChange = (newPage: number) => async () => {
+    console.log("Beginning page change")
     if (newPage < 1) {
       newPage = 1
     }
@@ -254,20 +257,27 @@ class QuizStatistics extends React.Component<any, any> {
     if (newPage > pages) {
       newPage = pages
     }
-    this.state.showingAll
-      ? this.props.setAllAnswers(
-          this.props.filter.quiz,
-          newPage,
-          this.state.answersPerPage,
-        )
-      : this.props.setAttentionRequiringAnswers(
-          this.props.filter.quiz,
-          newPage,
-          this.state.answersPerPage,
-        )
 
     this.setState({
       displayingPage: newPage,
+      waitingForNewAnswers: true,
+    })
+
+    if (this.state.showingAll) {
+      await this.props.setAllAnswers(
+        this.props.filter.quiz,
+        newPage,
+        this.state.answersPerPage,
+      )
+    } else {
+      await this.props.setAttentionRequiringAnswers(
+        this.props.filter.quiz,
+        newPage,
+        this.state.answersPerPage,
+      )
+    }
+    this.setState({
+      waitingForNewAnswers: false,
     })
   }
 }

--- a/packages/dashboard/src/components/Answers/QuizStatistics.tsx
+++ b/packages/dashboard/src/components/Answers/QuizStatistics.tsx
@@ -1,4 +1,4 @@
-import { CircularProgress, Grid, Typography } from "@material-ui/core"
+import { CircularProgress, Grid, Paper, Typography } from "@material-ui/core"
 import queryString from "query-string"
 import React from "react"
 import { connect } from "react-redux"
@@ -144,13 +144,22 @@ class QuizStatistics extends React.Component<any, any> {
                 </Grid>
 
                 <Grid item={true}>
-                  <Typography variant="subheading">
-                    {quiz.texts[0].title}
-                  </Typography>
-                </Grid>
-
-                <Grid item={true}>
-                  <Typography variant="body1">{quiz.texts[0].body}</Typography>
+                  <Paper
+                    style={{
+                      padding: "1em",
+                    }}
+                  >
+                    <Typography variant="h5">{quiz.texts[0].title}</Typography>
+                    <Typography
+                      variant="body1"
+                      style={{
+                        whiteSpace: "pre-wrap",
+                        wordBreak: "break-word",
+                      }}
+                    >
+                      {quiz.texts[0].body}
+                    </Typography>
+                  </Paper>
                 </Grid>
               </Grid>
             </Grid>

--- a/packages/dashboard/src/components/Answers/QuizStatistics.tsx
+++ b/packages/dashboard/src/components/Answers/QuizStatistics.tsx
@@ -76,7 +76,10 @@ class QuizStatistics extends React.Component<any, any> {
   }
 
   public render() {
-    const quiz = this.props.quizzes.find(
+    if (!this.props.quizzesOfCourse) {
+      return <p />
+    }
+    const quiz = this.props.quizzesOfCourse.quizzes.find(
       c => c.id === this.props.match.params.id,
     )
     const currentCourse = this.props.courses.find(
@@ -203,7 +206,9 @@ const mapStateToProps = (state: any) => {
   return {
     answerCounts: state.answerCounts,
     answers: state.answers,
-    quizzes: state.quizzes,
+    quizzesOfCourse: state.quizzes.find(
+      qi => qi.courseId === state.filter.course,
+    ),
     courses: state.courses,
     filter: state.filter,
   }

--- a/packages/dashboard/src/components/CoursesView.tsx
+++ b/packages/dashboard/src/components/CoursesView.tsx
@@ -88,7 +88,6 @@ const mapStateToProps = (state: any) => {
   return {
     courses: state.courses,
     filter: state.filter,
-    quizzes: state.quizzes,
   }
 }
 

--- a/packages/dashboard/src/components/DragHandleWrapper.tsx
+++ b/packages/dashboard/src/components/DragHandleWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentClass } from "react"
+import React from "react"
 import { SortableHandle } from "react-sortable-hoc"
 
 const DragHandleWrapper = SortableHandle((props: any) => (

--- a/packages/dashboard/src/components/Item.tsx
+++ b/packages/dashboard/src/components/Item.tsx
@@ -1,19 +1,5 @@
-import {
-  Card,
-  CardActions,
-  CardContent,
-  CardHeader,
-  Collapse,
-  Grid,
-  IconButton,
-  SvgIcon,
-  TextField,
-  Typography,
-} from "@material-ui/core"
-import Delete from "@material-ui/icons/Delete"
-import React, { ChangeEvent, createRef } from "react"
+import React, { createRef } from "react"
 import { connect } from "react-redux"
-import { executeIfOnlyDigitsInTextField } from "../../../common/src/util/index"
 import { changeOrder, remove } from "../store/edit/actions"
 import Checkbox from "./Checkbox"
 import CustomType from "./CustomType"
@@ -51,8 +37,6 @@ class Item extends React.Component<any, any> {
       expandedOptions: {},
     }
   }
-
-  // DISSPLAYNG THE ESSAY: SHOULD BE MORE UNIFORM WITH THE OTHERS!
 
   public expandOption = (order: number): void => {
     const newExpList: boolean[] = { ...this.state.expandedOptions }
@@ -119,17 +103,6 @@ class Item extends React.Component<any, any> {
 
   private toggleExpand = event => {
     this.props.expandItem(this.props.order)
-  }
-
-  private onOptionSortEnd = ({ oldIndex, newIndex, collection }) => {
-    const newExpList = { ...this.state.expandedOptions }
-    const temp = newExpList[oldIndex]
-    newExpList[oldIndex] = newExpList[newIndex]
-    newExpList[newIndex] = temp
-    this.setState({
-      expandedOptions: newExpList,
-    })
-    this.props.changeOrder(collection, oldIndex, newIndex)
   }
 }
 

--- a/packages/dashboard/src/components/Option.tsx
+++ b/packages/dashboard/src/components/Option.tsx
@@ -1,47 +1,18 @@
 import {
-  Button,
   Card,
   CardActions,
   CardContent,
   CardHeader,
   Checkbox,
-  Collapse,
-  Divider,
-  ExpansionPanel,
-  ExpansionPanelDetails,
-  ExpansionPanelSummary,
-  FormControl,
   FormControlLabel,
   Grid,
   IconButton,
-  InputLabel,
-  Menu,
-  MenuItem,
-  Paper,
-  Select,
   SvgIcon,
-  Switch,
   TextField,
-  Toolbar,
-  Typography,
 } from "@material-ui/core"
-import React, { createRef } from "react"
+import React from "react"
 import { connect } from "react-redux"
-import {
-  arrayMove,
-  SortableContainer,
-  SortableElement,
-  SortableHandle,
-} from "react-sortable-hoc"
-import {
-  addItem,
-  addOption,
-  changeAttr,
-  changeOrder,
-  newQuiz,
-  save,
-  setEdit,
-} from "../store/edit/actions"
+import { SortableElement } from "react-sortable-hoc"
 import DragHandleWrapper from "./DragHandleWrapper"
 
 class Option extends React.Component<any, any> {
@@ -219,7 +190,8 @@ const mapStateToProps = (state: any) => {
     courses: state.courses,
     edit: state.edit,
     filter: state.filter,
-    quizzes: state.quizzes,
+    quizzes: state.quizzes.find(qi => qi.courseId === state.filter.course)
+      .quizzes,
     user: state.user,
   }
 }

--- a/packages/dashboard/src/components/OptionContainer.tsx
+++ b/packages/dashboard/src/components/OptionContainer.tsx
@@ -1,48 +1,8 @@
-import {
-  Button,
-  Card,
-  CardActions,
-  CardContent,
-  CardHeader,
-  Collapse,
-  Divider,
-  ExpansionPanel,
-  ExpansionPanelDetails,
-  ExpansionPanelSummary,
-  FormControl,
-  Grid,
-  IconButton,
-  InputLabel,
-  Menu,
-  MenuItem,
-  Paper,
-  Select,
-  SvgIcon,
-  Switch,
-  TextField,
-  Toolbar,
-  Typography,
-} from "@material-ui/core"
-import Tab from "@material-ui/core/Tab"
-import Tabs from "@material-ui/core/Tabs"
+import { Button, Grid, Paper } from "@material-ui/core"
 import React from "react"
 import { connect } from "react-redux"
-import {
-  arrayMove,
-  SortableContainer,
-  SortableElement,
-  SortableHandle,
-} from "react-sortable-hoc"
-import {
-  addFinishedOption,
-  addItem,
-  addOption,
-  changeAttr,
-  changeOrder,
-  newQuiz,
-  save,
-  setEdit,
-} from "../store/edit/actions"
+import { SortableContainer } from "react-sortable-hoc"
+import { addFinishedOption, addOption } from "../store/edit/actions"
 import Option from "./Option"
 import OptionDialog from "./OptionDialog"
 

--- a/packages/dashboard/src/components/OptionDialog.tsx
+++ b/packages/dashboard/src/components/OptionDialog.tsx
@@ -6,13 +6,10 @@ import {
   Dialog,
   DialogActions,
   DialogContent,
-  DialogContentText,
   DialogTitle,
-  FormControlLabel,
   FormGroup,
   Grid,
   TextField,
-  Typography,
 } from "@material-ui/core"
 
 export default class OptionDialog extends React.Component<any, any> {

--- a/packages/dashboard/src/components/PeerReviewCollection.tsx
+++ b/packages/dashboard/src/components/PeerReviewCollection.tsx
@@ -5,46 +5,20 @@ import {
   CardContent,
   CardHeader,
   Collapse,
-  Divider,
-  ExpansionPanel,
-  ExpansionPanelDetails,
-  ExpansionPanelSummary,
-  FormControl,
   Grid,
   IconButton,
-  InputLabel,
   Menu,
   MenuItem,
   Paper,
-  Select,
   SvgIcon,
-  Switch,
-  Tab,
-  Tabs,
   TextField,
-  Toolbar,
   Typography,
 } from "@material-ui/core"
 import React from "react"
 import { connect } from "react-redux"
-import {
-  arrayMove,
-  SortableContainer,
-  SortableElement,
-  SortableHandle,
-} from "react-sortable-hoc"
-import {
-  addItem,
-  addOption,
-  addReviewQuestion,
-  changeAttr,
-  changeOrder,
-  newQuiz,
-  save,
-  setEdit,
-} from "../store/edit/actions"
+
+import { addReviewQuestion } from "../store/edit/actions"
 import DragHandleWrapper from "./DragHandleWrapper"
-import OptionContainer from "./OptionContainer"
 import PeerReviewQuestionContainer from "./PeerReviewQuestionContainer"
 
 class PeerReviewQuestionCollection extends React.Component<any, any> {

--- a/packages/dashboard/src/components/PeerReviewCollectionContainer.tsx
+++ b/packages/dashboard/src/components/PeerReviewCollectionContainer.tsx
@@ -1,52 +1,8 @@
-import {
-  Button,
-  Card,
-  CardActions,
-  CardContent,
-  CardHeader,
-  Collapse,
-  Divider,
-  ExpansionPanel,
-  ExpansionPanelDetails,
-  ExpansionPanelSummary,
-  FormControl,
-  Grid,
-  IconButton,
-  InputLabel,
-  Menu,
-  MenuItem,
-  Paper,
-  Select,
-  SvgIcon,
-  Switch,
-  Tab,
-  Tabs,
-  TextField,
-  Toolbar,
-  Typography,
-} from "@material-ui/core"
-import React, { ComponentClass } from "react"
+import React from "react"
 import { connect } from "react-redux"
-import {
-  arrayMove,
-  SortableContainer,
-  SortableElement,
-  SortableHandle,
-} from "react-sortable-hoc"
-import {
-  addItem,
-  addOption,
-  changeAttr,
-  changeOrder,
-  newQuiz,
-  save,
-  setEdit,
-} from "../store/edit/actions"
-import Item from "./Item"
-import OptionContainer from "./OptionContainer"
+import { SortableContainer } from "react-sortable-hoc"
+
 import PeerReviewCollection from "./PeerReviewCollection"
-import PeerReviewQuestion from "./PeerReviewQuestion"
-import SortableWrapper from "./SortableWrapper"
 
 const PeerReviewCollectionContainer = SortableContainer((props: any) => {
   return (

--- a/packages/dashboard/src/components/PeerReviewQuestion.tsx
+++ b/packages/dashboard/src/components/PeerReviewQuestion.tsx
@@ -1,52 +1,19 @@
 import {
-  Button,
   Card,
   CardActions,
   CardContent,
   CardHeader,
   Checkbox,
   Collapse,
-  Divider,
-  ExpansionPanel,
-  ExpansionPanelDetails,
-  ExpansionPanelSummary,
-  FormControl,
   FormControlLabel,
-  FormGroup,
   Grid,
   IconButton,
-  InputLabel,
-  Menu,
-  MenuItem,
-  Paper,
-  Select,
   SvgIcon,
-  Switch,
-  Tab,
-  Tabs,
   TextField,
-  Toolbar,
-  Typography,
 } from "@material-ui/core"
 import React from "react"
 import { connect } from "react-redux"
-import {
-  arrayMove,
-  SortableContainer,
-  SortableElement,
-  SortableHandle,
-} from "react-sortable-hoc"
-import {
-  addItem,
-  addOption,
-  changeAttr,
-  changeOrder,
-  newQuiz,
-  save,
-  setEdit,
-} from "../store/edit/actions"
 import DragHandleWrapper from "./DragHandleWrapper"
-import OptionContainer from "./OptionContainer"
 
 class PeerReviewQuestion extends React.Component<any, any> {
   constructor(props) {

--- a/packages/dashboard/src/components/PeerReviewQuestionContainer.tsx
+++ b/packages/dashboard/src/components/PeerReviewQuestionContainer.tsx
@@ -1,30 +1,3 @@
-import {
-  Button,
-  Card,
-  CardActions,
-  CardContent,
-  CardHeader,
-  Collapse,
-  Divider,
-  ExpansionPanel,
-  ExpansionPanelDetails,
-  ExpansionPanelSummary,
-  FormControl,
-  Grid,
-  IconButton,
-  InputLabel,
-  Menu,
-  MenuItem,
-  Paper,
-  Select,
-  SvgIcon,
-  Switch,
-  Tab,
-  Tabs,
-  TextField,
-  Toolbar,
-  Typography,
-} from "@material-ui/core"
 import React, { ComponentClass } from "react"
 import { connect } from "react-redux"
 import {
@@ -33,17 +6,6 @@ import {
   SortableElement,
   SortableHandle,
 } from "react-sortable-hoc"
-import {
-  addItem,
-  addOption,
-  changeAttr,
-  changeOrder,
-  newQuiz,
-  save,
-  setEdit,
-} from "../store/edit/actions"
-import Item from "./Item"
-import OptionContainer from "./OptionContainer"
 import PeerReviewQuestion from "./PeerReviewQuestion"
 import SortableWrapper from "./SortableWrapper"
 

--- a/packages/dashboard/src/components/QuizForm.tsx
+++ b/packages/dashboard/src/components/QuizForm.tsx
@@ -37,10 +37,6 @@ class QuizForm extends React.Component<any, any> {
   }
 
   public render() {
-    /* if (this.props.new && this.props.edit.id) {
-            return <Redirect to={`/quizzes/${this.props.edit.id}`} />
-        } */
-
     return (
       <Grid container={true} spacing={16} justify="center">
         <Grid item={true} xs={12} sm={10} lg={8}>
@@ -94,7 +90,6 @@ const mapStateToProps = (state: any) => {
     courses: state.courses,
     edit: state.edit,
     filter: state.filter,
-    quizzes: state.quizzes,
     user: state.user,
   }
 }

--- a/packages/dashboard/src/components/SingleCourseView.tsx
+++ b/packages/dashboard/src/components/SingleCourseView.tsx
@@ -209,7 +209,7 @@ const CourseComponent = ({ idx, countData, quiz }) => {
         justify="space-between"
         style={{ padding: ".5em 1em .5em 1em" }}
       >
-        <Grid item={true} xs={11} style={{ cursor: "pointer" }}>
+        <Grid item={true} xs={8} md={10} lg={11} style={{ cursor: "pointer" }}>
           <Link
             to={`/quizzes/${quiz.id}/answers`}
             style={{ textDecoration: "none" }}

--- a/packages/dashboard/src/components/SingleCourseView.tsx
+++ b/packages/dashboard/src/components/SingleCourseView.tsx
@@ -184,7 +184,7 @@ const SectionComponent = ({ quizzes, sectionNumber, answerCounts }) => {
             <CourseComponent
               idx={idx}
               quiz={q}
-              countData={answerCounts.find(a => a.quiz_id === q.id)}
+              countData={answerCounts.find(a => a.quizId === q.id)}
             />
           </Grid>
         )

--- a/packages/dashboard/src/components/SingleCourseView.tsx
+++ b/packages/dashboard/src/components/SingleCourseView.tsx
@@ -18,37 +18,46 @@ class SingleCourseView extends React.Component<any, any> {
   public componentDidUpdate() {
     if (
       !this.state.initialized &&
-      this.props.quizzes &&
-      this.props.quizzes.length > 0 &&
-      this.props.filter.course
+      this.props.quizzesOfCourse &&
+      this.props.quizzesOfCourse.quizzes &&
+      this.props.filter.course === this.props.match.params.id
     ) {
-      const newParts = {}
-
-      this.props.quizzes
-        .filter(q => q.courseId === this.props.filter.course)
-        .forEach(q => {
-          let sections = newParts[`${q.part}`]
-          if (!sections) {
-            sections = {}
-            newParts[`${q.part}`] = sections
-          }
-          let section = sections[`${q.section}`]
-          if (!section) {
-            section = []
-          }
-          section = section.concat(q)
-          sections[`${q.section}`] = section
-        })
-
-      this.setState({
-        parts: newParts,
-        initialized: true,
-      })
+      this.initialize()
     }
   }
 
+  public initialize = () => {
+    const newParts = {}
+
+    this.props.quizzesOfCourse.quizzes.forEach(q => {
+      let sections = newParts[`${q.part}`]
+      if (!sections) {
+        sections = {}
+        newParts[`${q.part}`] = sections
+      }
+      let section = sections[`${q.section}`]
+      if (!section) {
+        section = []
+      }
+      section = section.concat(q)
+      sections[`${q.section}`] = section
+    })
+
+    this.setState({
+      parts: newParts,
+      initialized: true,
+    })
+  }
+
   public componentDidMount() {
-    this.setState({ initialized: false })
+    if (
+      !this.state.initialized &&
+      this.props.quizzesOfCourse &&
+      this.props.quizzesOfCourse.quizzes &&
+      this.props.filter.course === this.props.match.params.id
+    ) {
+      this.initialize()
+    }
 
     if (
       this.props.match.params.id &&
@@ -60,11 +69,11 @@ class SingleCourseView extends React.Component<any, any> {
   }
 
   public render() {
-    if (this.props.courses.length === 0) {
+    if (!this.props.quizzesOfCourse) {
       return <div />
     }
     const currentCourse = this.props.courses.find(
-      course => this.props.filter.course === course.id,
+      course => this.props.match.params.id === course.id,
     )
     if (!currentCourse) {
       return <div />
@@ -265,7 +274,9 @@ const mapStateToProps = (state: any) => {
     answerCounts: state.answerCounts,
     courses: state.courses,
     filter: state.filter,
-    quizzes: state.quizzes,
+    quizzesOfCourse: state.quizzes.find(
+      qi => qi.courseId === state.filter.course,
+    ),
   }
 }
 

--- a/packages/dashboard/src/services/quizAnswers.ts
+++ b/packages/dashboard/src/services/quizAnswers.ts
@@ -8,7 +8,7 @@ export const getQuizAnswers = async (
   limit: number,
 ) => {
   const response = await axios.get(
-    `/api/v1/quizzes/answer/attention?quizId=${quizId}&attention=false&skip=${skip}&limit={limit}`,
+    `/api/v1/quizzes/answer/attention?quizId=${quizId}&attention=false&skip=${skip}&limit=${limit}`,
     {
       headers: { authorization: `Bearer ${user.accessToken}` },
     },

--- a/packages/dashboard/src/services/quizAnswers.ts
+++ b/packages/dashboard/src/services/quizAnswers.ts
@@ -1,8 +1,14 @@
 import axios from "axios"
+import { User } from "../../../../dist/common/src/models"
 
-export const getQuizAnswers = async (quizId, user) => {
+export const getQuizAnswers = async (
+  quizId: string,
+  user: any,
+  skip: number,
+  limit: number,
+) => {
   const response = await axios.get(
-    `/api/v1/quizzes/answer/attention?quizId=${quizId}&attention=false`,
+    `/api/v1/quizzes/answer/attention?quizId=${quizId}&attention=false&skip=${skip}&limit={limit}`,
     {
       headers: { authorization: `Bearer ${user.accessToken}` },
     },
@@ -11,14 +17,29 @@ export const getQuizAnswers = async (quizId, user) => {
   return response.data
 }
 
-export const getAttentionRequiringQuizAnswers = async (quizId, user) => {
+export const getAttentionRequiringQuizAnswers = async (
+  quizId: string,
+  user: any,
+  skip: number,
+  limit: number,
+) => {
   const response = await axios.get(
-    `/api/v1/quizzes/answer/attention?quizId=${quizId}&attention=true`,
+    `/api/v1/quizzes/answer/attention?quizId=${quizId}&attention=true&skip=${skip}&limit=${limit}`,
     {
       headers: { authorization: `Bearer ${user.accessToken}` },
     },
   )
 
+  return response.data
+}
+
+export const getTotalNumberOfAnswers = async (quizId: string, user: any) => {
+  const response = await axios.get(
+    `/api/v1/quizzes/answer/counts?quizId=${quizId}`,
+    {
+      headers: { authorization: `Bearer ${user.accessToken}` },
+    },
+  )
   return response.data
 }
 

--- a/packages/dashboard/src/services/quizAnswers.ts
+++ b/packages/dashboard/src/services/quizAnswers.ts
@@ -1,5 +1,4 @@
 import axios from "axios"
-import { User } from "../../../../dist/common/src/models"
 
 export const getQuizAnswers = async (
   quizId: string,

--- a/packages/dashboard/src/store/answerCounts/actions.ts
+++ b/packages/dashboard/src/store/answerCounts/actions.ts
@@ -27,6 +27,7 @@ export const setAllAnswersCount = (quizId: string) => {
         getState().user,
       )
       const oldData = getState().answerCounts
+
       const newData = oldData.map(countInfo => {
         if (countInfo.quizId !== quizId) {
           return countInfo

--- a/packages/dashboard/src/store/answerCounts/actions.ts
+++ b/packages/dashboard/src/store/answerCounts/actions.ts
@@ -1,4 +1,5 @@
 import { createAction } from "typesafe-actions"
+import { getTotalNumberOfAnswers } from "../../services/quizAnswers"
 import { getOddAnswerCountsByQuizzes } from "../../services/quizzes"
 
 export const set = createAction("answerCounts/SET", resolve => {
@@ -12,6 +13,33 @@ export const setAnswerCounts = () => {
     try {
       const data = await getOddAnswerCountsByQuizzes(getState().user)
       dispatch(set(data))
+    } catch (error) {
+      console.log(error)
+    }
+  }
+}
+
+export const setAllAnswersCount = (quizId: string) => {
+  return async (dispatch, getState) => {
+    try {
+      const totalCountInfo = await getTotalNumberOfAnswers(
+        quizId,
+        getState().user,
+      )
+      const oldData = getState().answerCounts
+      const newData = oldData.map(countInfo => {
+        if (countInfo.quizId !== quizId) {
+          return countInfo
+        }
+        console.log("This is the total count info: ", totalCountInfo)
+        const newNode = {
+          ...countInfo,
+          totalCount: totalCountInfo.count,
+        }
+        console.log("This is the new node", newNode)
+        return newNode
+      })
+      dispatch(set(newData))
     } catch (error) {
       console.log(error)
     }

--- a/packages/dashboard/src/store/answers/actions.ts
+++ b/packages/dashboard/src/store/answers/actions.ts
@@ -19,6 +19,7 @@ export const setAllAnswers = (
 ) => {
   return async (dispatch, getState) => {
     try {
+      // dispatch(clear())
       const data = await getQuizAnswers(
         quizId,
         getState().user,
@@ -39,6 +40,7 @@ export const setAttentionRequiringAnswers = (
 ) => {
   return async (dispatch, getState) => {
     try {
+      // dispatch(clear())
       const data = await getAttentionRequiringQuizAnswers(
         quizId,
         getState().user,

--- a/packages/dashboard/src/store/answers/actions.ts
+++ b/packages/dashboard/src/store/answers/actions.ts
@@ -4,6 +4,8 @@ import {
   getQuizAnswers,
 } from "../../services/quizAnswers"
 
+import { setQuizzes } from "../quizzes/actions"
+
 export const set = createAction("answers/SET", resolve => {
   return (quizzes: any[]) => resolve(quizzes)
 })
@@ -51,7 +53,8 @@ export const setAttentionRequiringAnswers = (
 
       const quiz = getState().quizzes.find(q => q.id === quizId)
       if (!quiz) {
-        console.log("quiz is undenfined...")
+        console.log("quiz undefined")
+        console.log("State: ", getState())
       }
 
       const peerReviewQuestions = quiz.peerReviewCollections

--- a/packages/dashboard/src/store/answers/actions.ts
+++ b/packages/dashboard/src/store/answers/actions.ts
@@ -26,7 +26,7 @@ export const setAllAnswers = (
         (wantedPageNumber - 1) * answersPerPage,
         answersPerPage,
       )
-      dispatch(set(data))
+      await dispatch(set(data))
     } catch (error) {
       console.log(error)
     }
@@ -87,7 +87,7 @@ export const setAttentionRequiringAnswers = (
         }
       })
 
-      dispatch(set(newData))
+      await dispatch(set(newData))
     } catch (error) {
       console.log(error)
     }

--- a/packages/dashboard/src/store/answers/actions.ts
+++ b/packages/dashboard/src/store/answers/actions.ts
@@ -10,10 +10,19 @@ export const set = createAction("answers/SET", resolve => {
 
 export const clear = createAction("answers/CLEAR")
 
-export const setAllAnswers = quizId => {
+export const setAllAnswers = (
+  quizId: string,
+  wantedPageNumber: number,
+  answersPerPage: number,
+) => {
   return async (dispatch, getState) => {
     try {
-      const data = await getQuizAnswers(quizId, getState().user)
+      const data = await getQuizAnswers(
+        quizId,
+        getState().user,
+        (wantedPageNumber - 1) * answersPerPage,
+        answersPerPage,
+      )
       dispatch(set(data))
     } catch (error) {
       console.log(error)
@@ -21,12 +30,18 @@ export const setAllAnswers = quizId => {
   }
 }
 
-export const setAttentionRequiringAnswers = quizId => {
+export const setAttentionRequiringAnswers = (
+  quizId: string,
+  pageNumber: number,
+  answersPerPage: number,
+) => {
   return async (dispatch, getState) => {
     try {
       const data = await getAttentionRequiringQuizAnswers(
         quizId,
         getState().user,
+        (pageNumber - 1) * answersPerPage,
+        answersPerPage,
       )
 
       if (data.length === 0) {

--- a/packages/dashboard/src/store/answers/actions.ts
+++ b/packages/dashboard/src/store/answers/actions.ts
@@ -50,6 +50,10 @@ export const setAttentionRequiringAnswers = (
       }
 
       const quiz = getState().quizzes.find(q => q.id === quizId)
+      if (!quiz) {
+        console.log("quiz is undenfined...")
+      }
+
       const peerReviewQuestions = quiz.peerReviewCollections
         .map(prc => prc.questions)
         .flat()

--- a/packages/dashboard/src/store/answers/actions.ts
+++ b/packages/dashboard/src/store/answers/actions.ts
@@ -53,7 +53,10 @@ export const setAttentionRequiringAnswers = (
         return
       }
 
-      const quiz = getState().quizzes.find(q => q.id === quizId)
+      const quiz = getState()
+        .quizzes.find(qi => qi.courseId === getState().filter.course)
+        .quizzes.find(q => q.id === quizId)
+
       if (!quiz) {
         console.log("quiz undefined")
         console.log("State: ", getState())

--- a/packages/dashboard/src/store/answers/reducer.ts
+++ b/packages/dashboard/src/store/answers/reducer.ts
@@ -2,14 +2,14 @@ import { ActionType, getType } from "typesafe-actions"
 import * as quizAnswers from "./actions"
 
 export const answersReducer = (
-  state: any[] = [],
+  state: any[] | null = null,
   action: ActionType<typeof quizAnswers>,
 ) => {
   switch (action.type) {
     case getType(quizAnswers.set):
       return [...action.payload]
     case getType(quizAnswers.clear):
-      return []
+      return null
     default:
       return state
   }

--- a/packages/dashboard/src/store/edit/actions.ts
+++ b/packages/dashboard/src/store/edit/actions.ts
@@ -40,11 +40,8 @@ export const save = () => {
   return async (dispatch, getState) => {
     try {
       const quiz = await post(getState().edit, getState().user)
-      const index = getState().quizzes.findIndex(q => q.id === quiz.id)
-      if (index > -1) {
-        dispatch(quizzes.remove(index))
-      }
-      dispatch(quizzes.set([quiz]))
+      dispatch(quizzes.set({ courseId: quiz.courseId, quizzes: [quiz] }))
+
       dispatch(setEdit(quiz))
       dispatch(
         displayMessage(`Successfully saved ${quiz.texts[0].title}!`, false),

--- a/packages/dashboard/src/store/filter/actions.ts
+++ b/packages/dashboard/src/store/filter/actions.ts
@@ -1,5 +1,6 @@
 import _ from "lodash"
 import { createAction } from "typesafe-actions"
+import { setCourses } from "../courses/actions"
 import { setQuizzes } from "../quizzes/actions"
 
 export const set = createAction("filter/SET", resolve => {
@@ -27,12 +28,20 @@ export const setLanguage = (language: string) => {
 
 export const setCourse = (course: string) => {
   return async (dispatch, getState) => {
-    if (!getState().quizzes.find(quiz => quiz.courseId === course)) {
-      await dispatch(setQuizzes(course))
+    if (!getState().courses.some(c => c.id === course)) {
+      await dispatch(setCourses())
     }
     const language = getState().courses.find(c => c.id === course).languages[0]
       .id
     dispatch(set({ course, language }))
+
+    if (
+      !getState().quizzes.find(
+        courseQuizzesInfo => courseQuizzesInfo.courseId === course,
+      )
+    ) {
+      await dispatch(setQuizzes(course))
+    }
   }
 }
 

--- a/packages/dashboard/src/store/quizzes/actions.ts
+++ b/packages/dashboard/src/store/quizzes/actions.ts
@@ -5,26 +5,27 @@ import * as Courses from "../courses/actions"
 import * as Filter from "../filter/actions"
 
 export const set = createAction("quizzes/SET", resolve => {
-  return (quizzes: any[]) => resolve(quizzes)
+  return (quizzes: ICourseQuizzes) => resolve(quizzes)
 })
 
 export const clear = createAction("quizzes/CLEAR")
 
 export const remove = createAction("quizzes/REMOVE", resolve => {
-  return (quizId: number) => resolve(quizId)
+  return (quizId: string) => resolve(quizId)
 })
 
 export const setQuizzes = course => {
   return async (dispatch, getState) => {
     try {
       const data = await getQuizzes(course, getState().user)
-      const cSet = new Set()
-      data.map(quiz => cSet.add(quiz.course.id))
-      const courses = data.filter(quiz => cSet.has(quiz.course.id))
-      dispatch(set(data))
-      // dispatch(Filter.setFilter("course", courses[0].course.id))
+      dispatch(set({ courseId: course, quizzes: data }))
     } catch (error) {
       console.log(error)
     }
   }
+}
+
+export interface ICourseQuizzes {
+  courseId: string
+  quizzes: any[]
 }

--- a/packages/dashboard/src/store/quizzes/reducer.ts
+++ b/packages/dashboard/src/store/quizzes/reducer.ts
@@ -3,17 +3,47 @@ import { Quiz } from "../../../../common/src/models/quiz"
 import * as quizzes from "./actions"
 
 export const quizzesReducer = (
-  state: any = [],
+  state: any[] = [],
   action: ActionType<typeof quizzes>,
 ) => {
   switch (action.type) {
     case getType(quizzes.set):
-      return [...state, ...action.payload]
+      const oldInfoExists = state.some(
+        qi => qi.courseId === action.payload.courseId,
+      )
+
+      if (!oldInfoExists) {
+        const newState = state.concat(action.payload)
+        return newState
+      }
+      // only updating a single quiz after saving
+      if (action.payload.quizzes.length === 1) {
+        const newQuizzes = [
+          ...state.find(qi => qi.courseId === action.payload.courseId).quizzes,
+        ].map(q =>
+          q.id === action.payload.quizzes[0].id ? action.payload.quizzes[0] : q,
+        )
+        return state.map(qi => ({
+          ...qi,
+          quizzes:
+            qi.courseId === action.payload.courseId ? newQuizzes : qi.quizzes,
+        }))
+      }
+
+      // otherwise assuming that everything has been fetched from db
+      return state.map(courseQuizzes =>
+        courseQuizzes.courseId === action.payload.courseId
+          ? action.payload
+          : courseQuizzes,
+      )
+
     case getType(quizzes.remove):
-      return [
-        ...state.slice(0, action.payload),
-        ...state.slice(action.payload + 1),
-      ]
+      return state.map(courseQuizzes => {
+        return {
+          ...courseQuizzes,
+          quizzes: courseQuizzes.quizzes.filter(q => q.id !== action.payload),
+        }
+      })
     case getType(quizzes.clear):
       return []
     default:


### PR DESCRIPTION
Changes: 
* Paging support for answers. Length of the page can be set to 10, 25, or 50 answers. Backend will return max 50 answers regardless of the value in the request.

* Hovering on an answer has no effect anymore. Instead, there is an expand button; clicking it shows the whole texts of lengthy answers and the summary of peer reviews / answer statistics. The button is visible only if the quiz includes peer reviews or some item answers are very long

* Old quizzes (yet to be replaced by new ones from the backend) are more transparent and non-interactable to indicate that loading is occurring

* The body text of the quiz is shown on answers page (since sometimes the answers are difficult to judge if the quiz item has no body)


Fixes: 
* 'All answers' selection in quiz answers page genuinely retrieves info on all the answers
* Course page shows always exactly the quizzes belonging to that course. While fixing the problem, changes were made to the organization of quizzes in the redux store (which explains the large number of files that were changed). The quizzes are now categorized by the course they belong to
* Various UI improvements in regards to different screen sizes