### PR TITLE
Effects of accept or reject buttons

### DIFF
--- a/packages/backend/src/controllers/courses/index.ts
+++ b/packages/backend/src/controllers/courses/index.ts
@@ -32,11 +32,6 @@ export class CourseController {
       throw new UnauthorizedError("unauthorized")
     }
 
-    console.log(
-      "Value of attentionAnswers inside the course controller: ",
-      attentionAnswers,
-    )
-
     const query: ICourseQuery = {
       id: null,
       language,

--- a/packages/backend/src/services/quiz.service.ts
+++ b/packages/backend/src/services/quiz.service.ts
@@ -26,7 +26,7 @@ export default class QuizService {
 
   public async getQuizzes(query: IQuizQuery): Promise<Quiz[]> {
     const queryBuilder = this.entityManager.createQueryBuilder(Quiz, "quiz")
-    const { courseId, exclude, id, language, stripped } = query
+    const { courseId, coursePart, exclude, id, language, stripped } = query
 
     if (language) {
       queryBuilder.leftJoinAndSelect(
@@ -133,6 +133,10 @@ export default class QuizService {
 
     if (courseId) {
       queryBuilder.andWhere("quiz.courseId = :courseId", { courseId })
+    }
+
+    if (coursePart) {
+      queryBuilder.andWhere("quiz.part = :part", { part: coursePart })
     }
 
     if (exclude) {

--- a/packages/backend/src/services/quizanswer.service.ts
+++ b/packages/backend/src/services/quizanswer.service.ts
@@ -107,6 +107,12 @@ export default class QuizAnswerService {
           "peer_review.quiz_answer_id = quiz_answer.id",
         )
         .leftJoinAndSelect("peer_review.answers", "peer_review_question_answer")
+        .leftJoinAndMapOne(
+          "quiz_answer.userQuizState",
+          UserQuizState,
+          "user_quiz_state",
+          "quiz_answer.user_id = user_quiz_state.user_id",
+        )
     }
 
     query = query
@@ -134,6 +140,12 @@ export default class QuizAnswerService {
           "peer_review.quiz_answer_id = quiz_answer.id",
         )
         .leftJoinAndSelect("peer_review.answers", "peer_review_question_answer")
+        .leftJoinAndMapOne(
+          "quiz_answer.userQuizState",
+          UserQuizState,
+          "user_quiz_state",
+          "quiz_answer.user_id = user_quiz_state.user_id",
+        )
     }
 
     query = query

--- a/packages/backend/src/services/quizanswer.service.ts
+++ b/packages/backend/src/services/quizanswer.service.ts
@@ -2,7 +2,7 @@ import { Inject, Service } from "typedi"
 import { EntityManager, SelectQueryBuilder } from "typeorm"
 import { InjectManager } from "typeorm-typedi-extensions"
 import { PeerReview, QuizAnswer, UserQuizState, SpamFlag } from "../models"
-import { IQuizAnswerQuery } from "../types"
+import { IQuizAnswerQuery, QuizAnswerStatus } from "../types"
 import { WhereBuilder } from "../util/index"
 import QuizService from "./quiz.service"
 

--- a/packages/backend/src/services/usercoursepartstate.service.ts
+++ b/packages/backend/src/services/usercoursepartstate.service.ts
@@ -1,0 +1,157 @@
+import { Inject, Service } from "typedi"
+import { EntityManager, SelectQueryBuilder } from "typeorm"
+import { InjectManager } from "typeorm-typedi-extensions"
+import {
+  Course,
+  Quiz,
+  QuizAnswer,
+  UserCourseState,
+  UserCoursePartState,
+  UserQuizState,
+} from "../models"
+import { IQuizAnswerQuery } from "../types"
+import CourseService from "./course.service"
+import QuizService from "./quiz.service"
+import QuizAnswerService from "./quizanswer.service"
+import UserQuizStateService from "./userquizstate.service"
+import { isBuffer } from "util"
+
+@Service()
+export default class UserCoursePartStateService {
+  @InjectManager()
+  private entityManager: EntityManager
+
+  @Inject()
+  private courseService: CourseService
+
+  @Inject()
+  private quizService: QuizService
+
+  @Inject()
+  private quizAnswerService: QuizAnswerService
+
+  @Inject()
+  private userQuizStateService: UserQuizStateService
+
+  public async getUserCoursePartState(
+    userId: number,
+    courseId: string,
+    partNumber: number,
+  ) {
+    return await this.entityManager
+      .createQueryBuilder(UserCoursePartState, "user_course_part_state")
+      .where("user_course_part_state.user_id = :userId", { userId })
+      .andWhere("user_course_part_state.course_id = :courseId", { courseId })
+      .andWhere("user_course_part_state.course_part = :course_part", {
+        course_part: partNumber,
+      })
+      .getOne()
+  }
+
+  public async getUserCoursePartStates(userId: number, courseId: string) {
+    return await this.entityManager
+      .createQueryBuilder(UserCoursePartState, "user_course_part_state")
+      .where("user_course_part_state.user_id = :userId", { userId })
+      .andWhere("user_course_part_state.course_id = :courseId", { courseId })
+      .getMany()
+  }
+
+  public async updateUserCoursePartState(
+    manager: EntityManager,
+    quiz: Quiz,
+    userId: number,
+  ): Promise<UserCoursePartState> {
+    let userCoursePartState = await this.getUserCoursePartState(
+      userId,
+      quiz.courseId,
+      quiz.part,
+    )
+    if (!userCoursePartState) {
+      return await this.createUserCoursePartState(
+        manager,
+        userId,
+        quiz.courseId,
+        quiz.part,
+      )
+    } else {
+      const quizzesInPart = await this.quizService.getQuizzes({
+        courseId: quiz.courseId,
+        coursePart: quiz.part,
+        exclude: true,
+      })
+
+      let pointsTotal: number = 0
+      const quizIds: string[] = quizzesInPart.map(quiz => {
+        pointsTotal += quiz.points
+        return quiz.id
+      })
+
+      const userQuizStates: UserQuizState[] = await this.userQuizStateService.getQuizStatesForUserCourse(
+        manager,
+        userId,
+        quizIds,
+      )
+
+      let pointsAwarded: number = 0
+
+      userQuizStates.forEach(uqs => {
+        pointsAwarded += uqs.pointsAwarded
+      })
+
+      userCoursePartState.score = (pointsAwarded / pointsTotal) * 100
+      userCoursePartState.progress =
+        (userQuizStates.length / quizzesInPart.length) * 100
+
+      if (userCoursePartState.score > 99.99) {
+        userCoursePartState.completed = true
+      }
+
+      return await manager.save(userCoursePartState)
+    }
+  }
+
+  public async createUserCoursePartState(
+    manager: EntityManager,
+    userId: number,
+    courseId: string,
+    coursePart: number,
+  ): Promise<UserCoursePartState> {
+    const quizzesInPart = await this.quizService.getQuizzes({
+      courseId: courseId,
+      coursePart: coursePart,
+      exclude: true,
+    })
+
+    let pointsTotal: number = 0
+    const quizIds: string[] = quizzesInPart.map(quiz => {
+      pointsTotal += quiz.points
+      return quiz.id
+    })
+
+    const userQuizStates: UserQuizState[] = await this.userQuizStateService.getQuizStatesForUserCourse(
+      manager,
+      userId,
+      quizIds,
+    )
+
+    const userCoursePartState: UserCoursePartState = new UserCoursePartState()
+
+    let pointsAwarded: number = 0
+    userQuizStates.forEach(uqs => {
+      pointsAwarded += uqs.pointsAwarded
+    })
+
+    userCoursePartState.userId = userId
+    userCoursePartState.courseId = courseId
+    userCoursePartState.coursePart = coursePart
+    userCoursePartState.score = (pointsAwarded / pointsTotal) * 100
+    userCoursePartState.progress =
+      (userQuizStates.length / quizzesInPart.length) * 100
+
+    if (userCoursePartState.score > 99.99) {
+      userCoursePartState.completed = true
+    }
+
+    return await manager.save(userCoursePartState)
+  }
+}

--- a/packages/backend/src/services/userquizstate.service.ts
+++ b/packages/backend/src/services/userquizstate.service.ts
@@ -2,16 +2,23 @@ import { Inject, Service } from "typedi"
 import { EntityManager, SelectQueryBuilder } from "typeorm"
 import { InjectManager } from "typeorm-typedi-extensions"
 import {
+  PeerReview,
+  PeerReviewCollection,
   Quiz,
   QuizAnswer,
   QuizItem,
   QuizItemAnswer,
+  SpamFlag,
   User,
   UserQuizState,
 } from "../models"
+import QuizAnswerService from "./quizanswer.service"
 
 @Service()
 export default class UserQuizStateService {
+  @Inject()
+  private quizAnswerService: QuizAnswerService
+
   @InjectManager()
   private entityManager: EntityManager
 
@@ -19,6 +26,8 @@ export default class UserQuizStateService {
     userId: number,
     quizId: string,
   ): Promise<UserQuizState | undefined> {
+    console.log("userId: ", userId)
+    console.log("quiz Id: ", quizId)
     return await this.entityManager
       .createQueryBuilder(UserQuizState, "userQuizState")
       .where("user_id = :userId and quiz_id = :quizId", { userId, quizId })
@@ -29,6 +38,84 @@ export default class UserQuizStateService {
     manager: EntityManager,
     userQuizState: UserQuizState,
   ): Promise<UserQuizState> {
+    return await manager.save(userQuizState)
+  }
+
+  // must have user id and quiz id set!
+  public async createAndCompleteUserQuizState(
+    manager: EntityManager,
+    userQuizState: UserQuizState,
+  ): Promise<UserQuizState> {
+    if (!userQuizState.userId || !userQuizState.quizId) {
+      return null
+    }
+
+    const quizAnswerIds = await manager
+      .createQueryBuilder(QuizAnswer, "quiz_answer")
+      .select("quiz_answer.id")
+      .where("quiz_answer.quiz_id = :quiz_id", {
+        quiz_id: userQuizState.quizId,
+      })
+      .andWhere("quiz_answer.user_id = :user_id", {
+        user_id: userQuizState.userId,
+      })
+
+    if (!userQuizState.spamFlags) {
+      userQuizState.spamFlags = (await manager
+        .createQueryBuilder(SpamFlag, "spam_flag")
+        .select("COUNT(*)")
+        .where("spam_flag.quiz_answer_id IN (" + quizAnswerIds.getQuery() + ")")
+        .setParameters(quizAnswerIds.getParameters())
+        .getRawOne()).count
+    }
+
+    if (!userQuizState.peerReviewsGiven) {
+      userQuizState.peerReviewsGiven = (await manager
+        .createQueryBuilder(PeerReview, "peer_review")
+        .select("COUNT(*)")
+        .leftJoin(
+          PeerReviewCollection,
+          "peer_review_collection",
+          "peer_review_collection.id = peer_review.peer_review_collection_id",
+        )
+        .where("peer_review.user_id = :user_id", {
+          user_id: userQuizState.userId,
+        })
+        .andWhere("peer_review_collection.quiz_id = :quiz_id", {
+          quiz_id: userQuizState.quizId,
+        })
+        .getRawOne()).count
+    }
+
+    if (!userQuizState.peerReviewsReceived) {
+      userQuizState.peerReviewsReceived = (await manager
+        .createQueryBuilder(PeerReview, "peer_review")
+        .select("COUNT(*)")
+        .where(
+          "peer_review.quiz_answer_id IN (" + quizAnswerIds.getQuery() + ")",
+        )
+        .setParameters(quizAnswerIds.getParameters())
+        .getRawOne()).count
+    }
+
+    if (!userQuizState.status) {
+      userQuizState.status = "locked"
+    }
+
+    if (!userQuizState.tries) {
+      // number of stored quiz answers - if multiple can be created?
+      userQuizState.tries = (await manager
+        .createQueryBuilder(QuizAnswer, "quiz_answer")
+        .select("COUNT(*)")
+        .where("quiz_answer.quiz_id = :quiz_id", {
+          quiz_id: userQuizState.quizId,
+        })
+        .andWhere("quiz_answer.user_id = :user_id", {
+          user_id: userQuizState.userId,
+        })
+        .getRawOne()).count
+    }
+
     return await manager.save(userQuizState)
   }
 

--- a/packages/backend/src/services/userquizstate.service.ts
+++ b/packages/backend/src/services/userquizstate.service.ts
@@ -72,7 +72,6 @@ export default class UserQuizStateService {
       typeof userQuizState.peerReviewsGiven !== "number" &&
       !userQuizState.peerReviewsGiven
     ) {
-      // change no not use peer review collection?
       userQuizState.peerReviewsGiven = (await manager
         .createQueryBuilder(PeerReview, "peer_review")
         .select("COUNT(*)")
@@ -109,7 +108,6 @@ export default class UserQuizStateService {
     }
 
     if (typeof userQuizState.tries !== "number" || userQuizState.tries === 0) {
-      // number of stored quiz answers - if multiple can be created?
       userQuizState.tries = (await manager
         .createQueryBuilder(QuizAnswer, "quiz_answer")
         .select("COUNT(*)")

--- a/packages/backend/src/services/userquizstate.service.ts
+++ b/packages/backend/src/services/userquizstate.service.ts
@@ -26,8 +26,6 @@ export default class UserQuizStateService {
     userId: number,
     quizId: string,
   ): Promise<UserQuizState | undefined> {
-    console.log("userId: ", userId)
-    console.log("quiz Id: ", quizId)
     return await this.entityManager
       .createQueryBuilder(UserQuizState, "userQuizState")
       .where("user_id = :userId and quiz_id = :quizId", { userId, quizId })

--- a/packages/backend/src/services/userquizstate.service.ts
+++ b/packages/backend/src/services/userquizstate.service.ts
@@ -39,7 +39,6 @@ export default class UserQuizStateService {
     return await manager.save(userQuizState)
   }
 
-  // must have user id and quiz id set!
   public async createAndCompleteUserQuizState(
     manager: EntityManager,
     userQuizState: UserQuizState,
@@ -58,7 +57,10 @@ export default class UserQuizStateService {
         user_id: userQuizState.userId,
       })
 
-    if (!userQuizState.spamFlags) {
+    if (
+      typeof userQuizState.spamFlags !== "number" &&
+      !userQuizState.spamFlags
+    ) {
       userQuizState.spamFlags = (await manager
         .createQueryBuilder(SpamFlag, "spam_flag")
         .select("COUNT(*)")
@@ -66,8 +68,11 @@ export default class UserQuizStateService {
         .setParameters(quizAnswerIds.getParameters())
         .getRawOne()).count
     }
-
-    if (!userQuizState.peerReviewsGiven) {
+    if (
+      typeof userQuizState.peerReviewsGiven !== "number" &&
+      !userQuizState.peerReviewsGiven
+    ) {
+      // change no not use peer review collection?
       userQuizState.peerReviewsGiven = (await manager
         .createQueryBuilder(PeerReview, "peer_review")
         .select("COUNT(*)")
@@ -85,7 +90,10 @@ export default class UserQuizStateService {
         .getRawOne()).count
     }
 
-    if (!userQuizState.peerReviewsReceived) {
+    if (
+      typeof userQuizState.peerReviewsReceived !== "number" &&
+      !userQuizState.peerReviewsReceived
+    ) {
       userQuizState.peerReviewsReceived = (await manager
         .createQueryBuilder(PeerReview, "peer_review")
         .select("COUNT(*)")
@@ -100,7 +108,7 @@ export default class UserQuizStateService {
       userQuizState.status = "locked"
     }
 
-    if (!userQuizState.tries) {
+    if (typeof userQuizState.tries !== "number" || userQuizState.tries === 0) {
       // number of stored quiz answers - if multiple can be created?
       userQuizState.tries = (await manager
         .createQueryBuilder(QuizAnswer, "quiz_answer")

--- a/packages/backend/src/types/index.d.ts
+++ b/packages/backend/src/types/index.d.ts
@@ -165,3 +165,11 @@ export interface INewPeerReviewCollectionTranslation {
   title: string
   body: string
 }
+
+export type QuizAnswerStatus =
+  | "draft"
+  | "submitted"
+  | "spam"
+  | "confirmed"
+  | "rejected"
+  | "deprecated"

--- a/packages/backend/src/types/index.d.ts
+++ b/packages/backend/src/types/index.d.ts
@@ -47,6 +47,7 @@ export interface IQuizQuery {
   id?: string
   courseId?: string
   courseAbbreviation?: string
+  coursePart?: number
   course?: boolean
   language?: string
   items?: boolean

--- a/packages/common/src/util/index.ts
+++ b/packages/common/src/util/index.ts
@@ -83,6 +83,15 @@ export function wordCount(str: string | null): number {
   return words ? words.length : 0
 }
 
+export function firstWords(str: string, n: number): string {
+  const words: string[] | null = str.match(/[^\s]+/g)
+  if (words === null) {
+    return ""
+  }
+
+  return words.splice(0, n).join(" ")
+}
+
 export function executeIfChangeMatches(
   test: (e: ChangeEvent<HTMLInputElement>) => boolean,
   failingDefaultValue: string | null = null,

--- a/packages/dashboard/src/components/Answers/Answer.tsx
+++ b/packages/dashboard/src/components/Answers/Answer.tsx
@@ -25,6 +25,14 @@ import PeerReviewsModal from "./PeerReviewsModal"
 class Answer extends React.Component<any, any> {
   private answerRef: React.RefObject<HTMLElement>
 
+  private borderColorsByStatus = {
+    submitted: "#FB6949",
+    spam: "#FB6949",
+    confirmed: "#48fa5d",
+    rejected: "#d80027",
+    deprecated: "#9b9b9b",
+  }
+
   constructor(props) {
     super(props)
     this.answerRef = React.createRef<HTMLElement>()
@@ -53,10 +61,7 @@ class Answer extends React.Component<any, any> {
             style={{
               borderLeft:
                 "1em solid " +
-                (this.props.answerData.status === "submitted" ||
-                this.props.answerData.status === "spam"
-                  ? "#FB6949"
-                  : "#49C7FB"),
+                this.borderColorsByStatus[this.props.answerData.status],
             }}
           >
             <Grid container={true} justify="center">
@@ -118,35 +123,39 @@ class Answer extends React.Component<any, any> {
                   }}
                 >
                   <Grid item={true} xs={6} lg={4}>
-                    <Grid container={true} justify="flex-start" spacing={16}>
-                      <Grid item={true} xs="auto">
-                        <Button
-                          variant="contained"
-                          style={{
-                            backgroundColor: "#029422",
-                            borderRadius: "0",
-                            color: "white",
-                          }}
-                          onClick={this.confirmStatusChange("accept")}
-                        >
-                          Accept
-                        </Button>
-                      </Grid>
+                    {this.props.answerData.status === "confirmed" ? (
+                      ""
+                    ) : (
+                      <Grid container={true} justify="flex-start" spacing={16}>
+                        <Grid item={true} xs="auto">
+                          <Button
+                            variant="contained"
+                            style={{
+                              backgroundColor: "#029422",
+                              borderRadius: "0",
+                              color: "white",
+                            }}
+                            onClick={this.confirmStatusChange("accept")}
+                          >
+                            Accept
+                          </Button>
+                        </Grid>
 
-                      <Grid item={true} xs="auto">
-                        <Button
-                          variant="contained"
-                          style={{
-                            backgroundColor: "#D80027",
-                            borderRadius: "0",
-                            color: "white",
-                          }}
-                          onClick={this.confirmStatusChange("reject")}
-                        >
-                          Reject
-                        </Button>
+                        <Grid item={true} xs="auto">
+                          <Button
+                            variant="contained"
+                            style={{
+                              backgroundColor: "#D80027",
+                              borderRadius: "0",
+                              color: "white",
+                            }}
+                            onClick={this.confirmStatusChange("reject")}
+                          >
+                            Reject
+                          </Button>
+                        </Grid>
                       </Grid>
-                    </Grid>
+                    )}
                   </Grid>
 
                   <Grid item={true} xs={2} style={{ textAlign: "center" }}>

--- a/packages/dashboard/src/components/Answers/Answer.tsx
+++ b/packages/dashboard/src/components/Answers/Answer.tsx
@@ -10,6 +10,7 @@ import ExpandLess from "@material-ui/icons/ExpandLess"
 import MoreVert from "@material-ui/icons/MoreVert"
 import React from "react"
 import { connect } from "react-redux"
+import { updateQuizAnswerStatus } from "../../services/quizAnswers"
 import { setCourse, setQuiz } from "../../store/filter/actions"
 import ItemAnswer from "./ItemAnswer"
 import PeerReviewsModal from "./PeerReviewsModal"
@@ -117,6 +118,10 @@ class Answer extends React.Component<any, any> {
                             borderRadius: "0",
                             color: "white",
                           }}
+                          onClick={this.modifyStatus(
+                            this.props.answerData.id,
+                            "accept",
+                          )}
                         >
                           Accept
                         </Button>
@@ -130,6 +135,10 @@ class Answer extends React.Component<any, any> {
                             borderRadius: "0",
                             color: "white",
                           }}
+                          onClick={this.modifyStatus(
+                            this.props.answerData.id,
+                            "reject",
+                          )}
                         >
                           Reject
                         </Button>
@@ -156,6 +165,19 @@ class Answer extends React.Component<any, any> {
         </Grid>
       </RootRef>
     )
+  }
+
+  private modifyStatus = (quizAnswerId: string, choice: string) => () => {
+    const message = `Are you sure you want to ${choice} the answer?`
+
+    if (confirm(message)) {
+      updateQuizAnswerStatus(
+        quizAnswerId,
+        choice === "accept" ? "confirmed" : "rejected",
+        this.props.user,
+      )
+      this.props.updateAnswers()
+    }
   }
 
   private itemAnswersDisplayedInFull = (answer): boolean => {
@@ -423,6 +445,7 @@ const mapStateToProps = state => {
       .quizzes,
     courses: state.courses,
     filter: state.filter,
+    user: state.user,
   }
 }
 

--- a/packages/dashboard/src/components/Answers/Answer.tsx
+++ b/packages/dashboard/src/components/Answers/Answer.tsx
@@ -86,6 +86,9 @@ class Answer extends React.Component<any, any> {
                       ).count
                     }
                     setQuiz={this.props.setQuiz}
+                    course={this.props.courses.find(
+                      c => c.id === this.props.filter.course,
+                    )}
                   />
                   <Grid item={true} xs="auto">
                     <IconButton onClick={this.showLess}>
@@ -242,6 +245,11 @@ class PeerReviewsSummary extends React.Component<any, any> {
           alignItems="stretch"
           spacing={8}
         >
+          <Grid item={true} xs={12} style={{ textAlign: "center" }}>
+            <Typography variant="subtitle1">
+              Status:{` ${this.props.answer.status}`}
+            </Typography>
+          </Grid>
           <Grid
             item={true}
             xs={12}
@@ -258,8 +266,37 @@ class PeerReviewsSummary extends React.Component<any, any> {
               <Grid item={true} xs={12}>
                 <Typography variant="subtitle1" color="textSecondary">
                   SPAM FLAGS: {this.props.spamFlags}
+                  {this.props.course.maxSpamFlags &&
+                    `. (Maximum allowed: ${this.props.course.maxSpamFlags})`}
                 </Typography>
               </Grid>
+              <Grid item={true} xs={12}>
+                <Typography variant="body1">
+                  Peer reviews given:{" "}
+                  {(this.props.answer.userQuizState &&
+                    this.props.answer.userQuizState.peerReviewsGiven) ||
+                    "none"}
+                  {this.props.course.minPeerReviewsGiven &&
+                    `. (Required: ${this.props.course.minPeerReviewsGiven})`}
+                </Typography>
+              </Grid>
+
+              <Grid item={true} xs={12}>
+                <Typography variant="body1">
+                  Peer reviews received: {this.props.peerReviewsAnswers.length}
+                  {this.props.course.minPeerReviewsReceived &&
+                    `. (Required: ${this.props.course.minPeerReviewsReceived})`}
+                </Typography>
+              </Grid>
+
+              {this.props.course.minReviewAverage && (
+                <Grid item={true} xs={12}>
+                  <Typography variant="body1">
+                    Minimum average of peer reviews:{" "}
+                    {this.props.course.minReviewAverage || "not set"}
+                  </Typography>
+                </Grid>
+              )}
 
               <Grid item={true} xs={12}>
                 <Button variant="outlined" onClick={this.openModal}>
@@ -384,6 +421,8 @@ const mapStateToProps = state => {
     answerStatistics: state.answerStatistics,
     quizzes: state.quizzes.find(qi => qi.courseId === state.filter.course)
       .quizzes,
+    courses: state.courses,
+    filter: state.filter,
   }
 }
 

--- a/packages/dashboard/src/components/Answers/Answers.tsx
+++ b/packages/dashboard/src/components/Answers/Answers.tsx
@@ -91,6 +91,7 @@ class AttentionAnswers extends React.Component<any, any> {
                       peerReviews={answer.peerReviews}
                       idx={idx}
                       quiz={this.props.quiz}
+                      updateAnswers={this.props.updateAnswers}
                     />
                   )
                 })}

--- a/packages/dashboard/src/components/Answers/QuizStatistics.tsx
+++ b/packages/dashboard/src/components/Answers/QuizStatistics.tsx
@@ -207,6 +207,7 @@ class QuizStatistics extends React.Component<any, any> {
                     onPageChange={this.handlePageChange}
                     resultsPerPage={this.state.answersPerPage}
                     changeResultsPerPage={this.handleChangeAnswersPerPage}
+                    updateAnswers={this.updateAnswers}
                   />
                 </Grid>
               </React.Fragment>
@@ -219,6 +220,20 @@ class QuizStatistics extends React.Component<any, any> {
         </Grid>
       </Grid>
     )
+  }
+
+  public updateAnswers = async () => {
+    ;(await this.state.showingAll)
+      ? this.props.setAllAnswers(
+          this.props.filter.quiz,
+          this.state.displayingPage,
+          this.state.answersPerPage,
+        )
+      : this.props.setAttentionRequiringAnswers(
+          this.props.filter.quiz,
+          this.state.displayingPage,
+          this.state.answersPerPage,
+        )
   }
 
   public handleChangeAnswersPerPage = async (

--- a/packages/dashboard/src/components/SingleCourseView.tsx
+++ b/packages/dashboard/src/components/SingleCourseView.tsx
@@ -247,7 +247,7 @@ const CourseComponent = ({ idx, countData, quiz }) => {
         </Grid>
         <Grid item={true} xs={6} style={{ cursor: "pointer" }}>
           <Link
-            to={`/quizzes/${quiz.id}/data`}
+            to={`/quizzes/${quiz.id}/answers`}
             style={{ textDecoration: "none" }}
           >
             <Typography variant="body1" style={{ color: "white" }}>

--- a/packages/dashboard/src/components/SingleCourseView.tsx
+++ b/packages/dashboard/src/components/SingleCourseView.tsx
@@ -2,6 +2,7 @@ import { Button, Card, Grid, Typography } from "@material-ui/core"
 import React from "react"
 import { connect } from "react-redux"
 import { Link } from "react-router-dom"
+import { firstWords, wordCount } from "../../../common/src/util"
 import { newQuiz } from "../store/edit/actions"
 import { setCourse } from "../store/filter/actions"
 import LanguageBar from "./GeneralTools/LanguageBar"
@@ -216,6 +217,7 @@ const CourseComponent = ({ idx, countData, quiz }) => {
       <Grid
         container={true}
         justify="space-between"
+        alignItems="center"
         style={{ padding: ".5em 1em .5em 1em" }}
       >
         <Grid item={true} xs={8} md={10} lg={11} style={{ cursor: "pointer" }}>
@@ -245,20 +247,28 @@ const CourseComponent = ({ idx, countData, quiz }) => {
             </Button>
           </Link>
         </Grid>
-        <Grid item={true} xs={6} style={{ cursor: "pointer" }}>
+
+        <Grid item={true} xs={9} style={{ cursor: "pointer" }}>
           <Link
-            to={`/quizzes/${quiz.id}/answers`}
+            to={`/quizzes/${quiz.id}/data`}
             style={{ textDecoration: "none" }}
           >
             <Typography variant="body1" style={{ color: "white" }}>
-              {quiz.texts[0].title}
+              {wordCount(quiz.texts[0].body) < 15
+                ? quiz.texts[0].body
+                : firstWords(quiz.texts[0].body, 15) + " ..."}
             </Typography>
           </Link>
         </Grid>
 
         {countData && countData.count > 0 && (
-          <Grid item={true} xs="auto">
-            <Typography variant="body1">
+          <Grid item={true} xs={3}>
+            <Typography
+              variant="body1"
+              style={{
+                textAlign: "right",
+              }}
+            >
               {countData.count} answer{countData.count === 1 ? "" : "s"}{" "}
               requiring attention
             </Typography>

--- a/packages/dashboard/src/services/quizAnswers.ts
+++ b/packages/dashboard/src/services/quizAnswers.ts
@@ -23,7 +23,9 @@ export const updateQuizAnswerStatus = async (
 ) => {
   const response = await axios.post(
     `/api/v1/quizzes/answer/${quizAnswerId}`,
-    newStatus,
+    {
+      newStatus,
+    },
     {
       headers: { authorization: `Bearer ${user.accessToken}` },
     },

--- a/packages/dashboard/src/services/quizAnswers.ts
+++ b/packages/dashboard/src/services/quizAnswers.ts
@@ -30,8 +30,6 @@ export const updateQuizAnswerStatus = async (
       headers: { authorization: `Bearer ${user.accessToken}` },
     },
   )
-
-  console.log("Response to answer status update ", response.data)
   return response.data
 }
 

--- a/packages/dashboard/src/services/quizAnswers.ts
+++ b/packages/dashboard/src/services/quizAnswers.ts
@@ -16,6 +16,23 @@ export const getQuizAnswers = async (
   return response.data
 }
 
+export const updateQuizAnswerStatus = async (
+  quizAnswerId: string,
+  newStatus: string,
+  user: any,
+) => {
+  const response = await axios.post(
+    `/api/v1/quizzes/answer/${quizAnswerId}`,
+    newStatus,
+    {
+      headers: { authorization: `Bearer ${user.accessToken}` },
+    },
+  )
+
+  console.log("Response to answer status update ", response.data)
+  return response.data
+}
+
 export const getAttentionRequiringQuizAnswers = async (
   quizId: string,
   user: any,

--- a/packages/dashboard/src/store/answerCounts/actions.ts
+++ b/packages/dashboard/src/store/answerCounts/actions.ts
@@ -8,6 +8,10 @@ export const set = createAction("answerCounts/SET", resolve => {
 
 export const clear = createAction("answerCounts/CLEAR")
 
+export const decrement = createAction("answerCounts/DECREMENT", resolve => {
+  return (quizId: string) => resolve(quizId)
+})
+
 export const setAnswerCounts = () => {
   return async (dispatch, getState) => {
     try {
@@ -32,12 +36,10 @@ export const setAllAnswersCount = (quizId: string) => {
         if (countInfo.quizId !== quizId) {
           return countInfo
         }
-        console.log("This is the total count info: ", totalCountInfo)
         const newNode = {
           ...countInfo,
           totalCount: totalCountInfo.count,
         }
-        console.log("This is the new node", newNode)
         return newNode
       })
       dispatch(set(newData))

--- a/packages/dashboard/src/store/answerCounts/actions.ts
+++ b/packages/dashboard/src/store/answerCounts/actions.ts
@@ -30,7 +30,12 @@ export const setAllAnswersCount = (quizId: string) => {
         quizId,
         getState().user,
       )
-      const oldData = getState().answerCounts
+
+      let oldData = getState().answerCounts
+      if (oldData.length === 0) {
+        await dispatch(setAnswerCounts())
+        oldData = getState().answerCounts
+      }
 
       const newData = oldData.map(countInfo => {
         if (countInfo.quizId !== quizId) {

--- a/packages/dashboard/src/store/answerCounts/reducer.ts
+++ b/packages/dashboard/src/store/answerCounts/reducer.ts
@@ -3,7 +3,7 @@ import * as quizAnswerCounts from "./actions"
 
 interface IQuizAnswerStatistic {
   quizId: string
-  answerCount: number
+  count: number
 }
 
 export const answerCountsReducer = (
@@ -15,6 +15,15 @@ export const answerCountsReducer = (
       return [...action.payload]
     case getType(quizAnswerCounts.clear):
       return []
+    case getType(quizAnswerCounts.decrement):
+      const quizId = action.payload
+      return state.map(ac => {
+        if (ac.quizId !== quizId) {
+          return ac
+        } else {
+          return { ...ac, count: ac.count - 1 }
+        }
+      })
     default:
       return state
   }


### PR DESCRIPTION

Changes: 
- Clicking 'accept' / 'reject' causes the status of the answer to change, after the user confirms their choice.
- Status changing to 'confirmed' causes the updates in UserQuizState, UserCoursePartState, and UserCourseState. If any of these does not exist, a new object is created and the properties calculated from other tables (e.g. number of given peer reviews). UserQuizState is updated also in case of status changing to 'rejected'.
- UserCourseState is returned along with the answer (so more information can be displayed on the quiz answers page, e.g. how many peer reviews the answerer has given to others)
- Buttons to accept/reject are not shown on answers whose status is confirmed. Could be something that we want to allow in some cases, but would require changes also in the backend (need to update the progress/points in the negative direction)
- The color of the left border of the answer displays the status: strong red is rejected, green confirmed, gray deprecated, and the light orange/red is spam/submitted. Status also shown as text when the answer is expanded.


Fixes: 
- The displayed number of all answers is correct even if the user navigates directly to the page showing all answers (earlier led to no number being displayed)
- Quiz components on course page show (the start of) the quiz body, instead of the title for the second time Clicking the body leads to a real address

