### PR TITLE
Getting rid of the rest of type errors

### DIFF
--- a/packages/moocfi-quizzes/src/components/Essay.tsx
+++ b/packages/moocfi-quizzes/src/components/Essay.tsx
@@ -34,7 +34,7 @@ const Essay: React.FunctionComponent<EssayProps> = ({ item }) => {
   let itemAnswer = quizAnswer.itemAnswers.find(ia => ia.quizItemId === item.id)
 
   if (!itemAnswer) {
-    return <LaterQuizItemAddition item={item} message="You have not answered" />
+    return <LaterQuizItemAddition item={item} />
   }
 
   const answerText = itemAnswer.textData || ""

--- a/packages/moocfi-quizzes/src/components/QuizImpl/index.tsx
+++ b/packages/moocfi-quizzes/src/components/QuizImpl/index.tsx
@@ -181,9 +181,8 @@ const FuncQuizImpl: React.FunctionComponent<QuizProps> = ({
 
             <Typography>
               {quiz.triesLimited
-                ? `Tries remaining: ${triesRemaining}`
-                : // ...or just say nothing, but let's see if anything shows up
-                  "Unlimited tries"}
+                ? `${generalLabels.triesRemainingLabel}: ${triesRemaining}`
+                : ""}
             </Typography>
             <Button
               variant="contained"

--- a/packages/moocfi-quizzes/src/components/Scale.tsx
+++ b/packages/moocfi-quizzes/src/components/Scale.tsx
@@ -53,7 +53,7 @@ const Scale: React.FunctionComponent<ScaleProps> = ({ item }) => {
   const intData = itemAnswer && itemAnswer.intData
 
   if (!itemAnswer) {
-    return <LaterQuizItemAddition item={item} message="You have not answered" />
+    return <LaterQuizItemAddition item={item} />
   }
 
   return (

--- a/packages/moocfi-quizzes/src/utils/languages/english_options.ts
+++ b/packages/moocfi-quizzes/src/utils/languages/english_options.ts
@@ -56,6 +56,7 @@ const englishLabels: SingleLanguageLabels = {
     pointsReceivedLabel: "Points awarded to you",
     incorrectSubmitWhileTriesLeftLabel:
       "The answer was incorrect - you may try again!",
+    triesRemainingLabel: "Tries remaining",
   },
 }
 

--- a/packages/moocfi-quizzes/src/utils/languages/finnish_options.ts
+++ b/packages/moocfi-quizzes/src/utils/languages/finnish_options.ts
@@ -58,6 +58,7 @@ const finnishLabels: SingleLanguageLabels = {
     pointsReceivedLabel: "Saamasi pisteet",
     incorrectSubmitWhileTriesLeftLabel:
       "Vastauksesi oli virheellinen - voit yrittää uudelleen!",
+    triesRemainingLabel: "Yrityksiä jäljellä",
   },
 }
 

--- a/packages/moocfi-quizzes/src/utils/languages/index.ts
+++ b/packages/moocfi-quizzes/src/utils/languages/index.ts
@@ -14,6 +14,7 @@ export type GeneralLabels = {
   pointsAvailableLabel: string
   pointsReceivedLabel: string
   incorrectSubmitWhileTriesLeftLabel: string
+  triesRemainingLabel: string
 }
 
 export type StageLabels = {

--- a/packages/moocfi-quizzes/tsconfig.json
+++ b/packages/moocfi-quizzes/tsconfig.json
@@ -18,7 +18,8 @@
     "typeRoots": [
       "index.d.ts",
       "node_modules/@types"
-    ]
+    ],
+    "types": ["node"]
   },
   "include": [
     "./src/**/*.tsx",


### PR DESCRIPTION
Own code: 
* removed erroneous parameters

Dependencies: 
* Duplicate types since @types/react-native in styled-components dependencies. Solution used: 
https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33015#issuecomment-463985597

Other changes: 
* if unlimited tries, no special text shown above the submit button