### PR TITLE
Items containing options should not produce null related errors

### DIFF
--- a/packages/dashboard/src/components/MultipleChoice/ExpandedMultipleChoiceItem.tsx
+++ b/packages/dashboard/src/components/MultipleChoice/ExpandedMultipleChoiceItem.tsx
@@ -287,13 +287,12 @@ class MultipleChoiceItem extends React.Component<any, any> {
 
   private handleSubmission = (itemId: string) => optionData => event => {
     this.handleClose()
-
     const newOption = {
       title: optionData.title,
       body: optionData.body,
       successMessage: optionData.successMessage,
       failureMessage: optionData.failureMessage,
-      correct: optionData.correct,
+      correct: optionData.correct !== null ? optionData.correct : false,
       order: this.state.tempItemData.options.length,
       quizItemId: itemId,
     }

--- a/packages/dashboard/src/components/ResearchAgreement/ExpandedResearchAgreement.tsx
+++ b/packages/dashboard/src/components/ResearchAgreement/ExpandedResearchAgreement.tsx
@@ -31,6 +31,7 @@ class ExpandedResearchAgreement extends React.Component<any, any> {
       titleHasBeenModified: item.id ? true : false,
       order: option.order,
       id: option.id,
+      correct: true,
     }))
 
     const initData = {
@@ -150,6 +151,7 @@ class ExpandedResearchAgreement extends React.Component<any, any> {
           order: oldOptions.length,
           titleHasBeenModified: true,
           id: null,
+          correct: true,
         }),
       },
     })

--- a/packages/dashboard/src/store/edit/actions.ts
+++ b/packages/dashboard/src/store/edit/actions.ts
@@ -164,9 +164,9 @@ export const updateMultipleOptions = (itemOrder, optionData) => {
       const optData = optionData.find(od => od.order === option.order)
       option.texts[0].title = optData.title
       option.texts[0].body = optData.body
-      ;(option.correct = optData.correct),
-        (option.texts[0].failureMessage = optData.failureMessage),
-        (option.texts[0].successMessage = optData.successMessage)
+      option.correct = optData.correct
+      option.texts[0].failureMessage = optData.failureMessage
+      option.texts[0].successMessage = optData.successMessage
     })
     dispatch(setEdit(quiz))
   }


### PR DESCRIPTION
Earlier it was possible that an untouched option had null as the value of the correct field, which produced an error in saving the quiz (item). 