### PR TITLE
Submitting an incorrect quiz won't cause error

### DIFF
--- a/packages/moocfi-quizzes/src/services/answerService.ts
+++ b/packages/moocfi-quizzes/src/services/answerService.ts
@@ -3,7 +3,7 @@ import BASE_URL from "../config"
 import { Quiz, QuizAnswer, UserQuizState } from "../modelTypes"
 
 type AnswerResponse = {
-  quiz: Quiz
+  quiz?: Quiz
   quizAnswer: QuizAnswer
   userQuizState: UserQuizState
 }

--- a/packages/moocfi-quizzes/src/state/quizAnswer/actions.ts
+++ b/packages/moocfi-quizzes/src/state/quizAnswer/actions.ts
@@ -92,11 +92,16 @@ export const submit: ActionCreator<ThunkAction> = () => async (
   dispatch,
   getState,
 ) => {
-  const { quiz, quizAnswer, userQuizState } = await postAnswer(
+  let { quiz, quizAnswer, userQuizState } = await postAnswer(
     getState().quizAnswer.quizAnswer,
     getState().user.accessToken,
     getState().backendAddress,
   )
+
+  // wrong answer -> quiz not returned
+  if (!quiz) {
+    quiz = getState().quiz
+  }
 
   dispatch(userActions.setQuizState(userQuizState))
 


### PR DESCRIPTION
There was a possibility of an undefined quiz that was not taken into account in the typings