### PR TITLE
Logged out handling

### DIFF
--- a/packages/moocfi-quizzes/src/components/QuizImpl/CustomContentQuiz.tsx
+++ b/packages/moocfi-quizzes/src/components/QuizImpl/CustomContentQuiz.tsx
@@ -1,0 +1,49 @@
+import * as React from "react"
+import styled from "styled-components"
+import { Typography } from "@material-ui/core"
+import TopInfoBar from "./TopInfoBar"
+import { useTypedSelector } from "../../state/store"
+
+interface ICustomContentQuizProps {
+  content?: Element | JSX.Element
+}
+
+// some of the height depends on rem - might not be exact
+const ContentWrapper = styled.div`
+  min-height: 460px;
+`
+
+const CustomContentQuiz: React.FunctionComponent<ICustomContentQuizProps> = ({
+  content,
+}) => {
+  const contents = content || <DefaultLoginMessage />
+  return (
+    <>
+      <TopInfoBar staticBars={true} />
+
+      <ContentWrapper>{contents}</ContentWrapper>
+    </>
+  )
+}
+
+const DefaultLoginMessage = () => {
+  const languageLabels = useTypedSelector(
+    state => state.language.languageLabels,
+  )
+
+  return (
+    <MessageContainer>
+      <Typography variant="subtitle1">
+        {languageLabels
+          ? languageLabels.general.loginPromptLabel
+          : "Log in to view the quiz."}
+      </Typography>
+    </MessageContainer>
+  )
+}
+
+const MessageContainer = styled.div`
+  padding: 1rem;
+`
+
+export default CustomContentQuiz

--- a/packages/moocfi-quizzes/src/components/QuizImpl/TopInfoBar.tsx
+++ b/packages/moocfi-quizzes/src/components/QuizImpl/TopInfoBar.tsx
@@ -33,7 +33,14 @@ const RightMarginedGrid = styled(Grid)`
   margin-right: 1.5rem;
 `
 
-const TopInfoBar: React.FunctionComponent = () => {
+interface ITopInfoBarProps {
+  // when the user is not logged in
+  staticBars?: boolean
+}
+
+const TopInfoBar: React.FunctionComponent<ITopInfoBarProps> = ({
+  staticBars,
+}) => {
   const userQuizState = useTypedSelector(state => state.user.userQuizState)
   const quiz = useTypedSelector(state => state.quiz)
   const languageInfo = useTypedSelector(state => state.language.languageLabels)
@@ -59,39 +66,43 @@ const TopInfoBar: React.FunctionComponent = () => {
     formattedReceivedPoints = ""
     availablePoints = ""
 
-    titleReplacement = displayBars ? (
-      <ContentLoader
-        height={40}
-        width={100}
-        speed={2}
-        primaryColor="#ffffff"
-        primaryOpacity={0.6}
-        secondaryColor="#dddddd"
-        secondaryOpacity={0.6}
-        style={{ width: "300px", height: "31.2px" }}
-      >
-        <rect x="0" y="10" rx="4" ry="20" width="100" height="30" />
-      </ContentLoader>
-    ) : (
-      <div style={{ height: "31.2px" }} />
-    )
+    titleReplacement =
+      displayBars || staticBars ? (
+        <ContentLoader
+          animate={staticBars ? false : true}
+          height={40}
+          width={100}
+          speed={2}
+          primaryColor="#ffffff"
+          primaryOpacity={0.6}
+          secondaryColor="#dddddd"
+          secondaryOpacity={0.6}
+          style={{ width: "300px", height: "31.2px" }}
+        >
+          <rect x="0" y="10" rx="4" ry="20" width="100" height="30" />
+        </ContentLoader>
+      ) : (
+        <div style={{ height: "31.2px" }} />
+      )
 
-    pointsReplacement = displayBars ? (
-      <ContentLoader
-        height={40}
-        width={100}
-        speed={2}
-        primaryColor="#ffffff"
-        primaryOpacity={0.6}
-        secondaryColor="#dddddd"
-        secondaryOpacity={0.6}
-        style={{ width: "45px", height: "31.2px" }}
-      >
-        <rect x="0" y="10" rx="25" ry="25" width="100" height="30" />
-      </ContentLoader>
-    ) : (
-      <div style={{ height: "31.2px" }} />
-    )
+    pointsReplacement =
+      displayBars || staticBars ? (
+        <ContentLoader
+          animate={staticBars ? false : true}
+          height={40}
+          width={100}
+          speed={2}
+          primaryColor="#ffffff"
+          primaryOpacity={0.6}
+          secondaryColor="#dddddd"
+          secondaryOpacity={0.6}
+          style={{ width: "45px", height: "31.2px" }}
+        >
+          <rect x="0" y="10" rx="25" ry="25" width="100" height="30" />
+        </ContentLoader>
+      ) : (
+        <div style={{ height: "31.2px" }} />
+      )
   } else {
     title = quiz.texts[0].title
 

--- a/packages/moocfi-quizzes/src/components/QuizImpl/index.tsx
+++ b/packages/moocfi-quizzes/src/components/QuizImpl/index.tsx
@@ -5,6 +5,7 @@ import styled from "styled-components"
 import { CircularProgress, Grid, Typography } from "@material-ui/core"
 import * as quizAnswerActions from "../../state/quizAnswer/actions"
 import * as messageActions from "../../state/message/actions"
+import * as languageActions from "../../state/language/actions"
 
 import { initialize } from "../../state/actions"
 import Checkbox from "../CheckboxOption"
@@ -24,6 +25,7 @@ import { Quiz, QuizItemType } from "../../modelTypes"
 import LoadingQuiz from "./LoadingQuiz"
 import TopInfoBar from "./TopInfoBar"
 import SubmitButton from "./SubmitButton"
+import CustomContentQuiz from "./CustomContentQuiz"
 import MarkdownText from "../MarkdownText"
 
 const componentsByTypeNames = (typeName: QuizItemType) => {
@@ -46,6 +48,7 @@ export interface QuizProps {
   languageId: string
   accessToken: string
   backendAddress?: string
+  customContent?: Element | JSX.Element
 }
 
 const QuizItemContainerDiv = styled.div`
@@ -72,6 +75,7 @@ const FuncQuizImpl: React.FunctionComponent<QuizProps> = ({
   languageId,
   accessToken,
   backendAddress,
+  customContent,
 }) => {
   const submitLocked = useTypedSelector(state => state.quizAnswer.submitLocked)
   const messageState = useTypedSelector(state => state.message)
@@ -85,8 +89,16 @@ const FuncQuizImpl: React.FunctionComponent<QuizProps> = ({
   const error = messageState.errorMessage
 
   useEffect(() => {
-    dispatch(initialize(id, languageId, accessToken, backendAddress))
+    if (accessToken) {
+      dispatch(initialize(id, languageId, accessToken, backendAddress))
+    } else if (languageId) {
+      dispatch(languageActions.set(languageId))
+    }
   }, [])
+
+  if (customContent || !accessToken) {
+    return <CustomContentQuiz content={customContent} />
+  }
 
   if (!quiz || !languageInfo || !quizAnswer) {
     return <LoadingQuiz />
@@ -109,10 +121,6 @@ const FuncQuizImpl: React.FunctionComponent<QuizProps> = ({
           })}
       </>
     )
-  }
-
-  if (!accessToken) {
-    return <div>{generalLabels.loginPromptLabel}</div>
   }
 
   if (error) {

--- a/packages/moocfi-quizzes/src/utils/languages/english_options.ts
+++ b/packages/moocfi-quizzes/src/utils/languages/english_options.ts
@@ -65,7 +65,7 @@ const englishLabels: SingleLanguageLabels = {
       "Question not answered. Quiz has probably been modified after your answer.",
     submitButtonLabel: "Submit",
     errorLabel: "Error",
-    loginPromptLabel: "Login to view the quiz",
+    loginPromptLabel: "Log in to view the quiz",
     loadingLabel: "Loading",
     answerCorrectLabel: "The answer is correct",
     alreadyAnsweredLabel: "You have already answered",


### PR DESCRIPTION
If there is no access token as a parameter: 
* Blank bars is shown in the top information bar in place of title / point info
* In the content area, either the default text guiding to login, or the JSX element supplied as a prop, is dispayed

The content prop could be used in other cases than missing access token in the future, too.