### PR TITLE
Prettier login separation

### DIFF
--- a/packages/moocfi-quizzes/src/components/QuizImpl/LoginPrompt.tsx
+++ b/packages/moocfi-quizzes/src/components/QuizImpl/LoginPrompt.tsx
@@ -9,8 +9,7 @@ interface ILoginPromptProps {
 }
 
 const StyledDivider = styled(Divider)`
-  height: 3px;
-  background-color: #000000;
+  height: 2px;
 `
 
 const LoginPrompt: React.FunctionComponent<ILoginPromptProps> = ({

--- a/packages/moocfi-quizzes/src/components/QuizImpl/LoginPrompt.tsx
+++ b/packages/moocfi-quizzes/src/components/QuizImpl/LoginPrompt.tsx
@@ -1,12 +1,17 @@
 import * as React from "react"
 import styled from "styled-components"
-import { Typography } from "@material-ui/core"
+import { Divider, Typography } from "@material-ui/core"
 import { useTypedSelector } from "../../state/store"
 
 interface ILoginPromptProps {
   content?: Element | JSX.Element
   fullQuizInfoShown?: boolean
 }
+
+const StyledDivider = styled(Divider)`
+  height: 3px;
+  background-color: #000000;
+`
 
 const LoginPrompt: React.FunctionComponent<ILoginPromptProps> = ({
   content,
@@ -34,13 +39,16 @@ const DefaultLoginMessage: React.FunctionComponent<
   }PromptLabel`
 
   return (
-    <MessageContainer fullQuizInfoShown={!!fullQuizInfoShown}>
-      <StyledTypography variant="subtitle1">
-        {languageLabels
-          ? languageLabels.general[labelPropertyName]
-          : `Log in to ${fullQuizInfoShown ? "answer" : "view"} the quiz`}
-      </StyledTypography>
-    </MessageContainer>
+    <>
+      <MessageContainer fullQuizInfoShown={!!fullQuizInfoShown}>
+        <StyledTypography variant="subtitle1">
+          {languageLabels
+            ? languageLabels.general[labelPropertyName]
+            : `Log in to ${fullQuizInfoShown ? "answer" : "view"} the quiz`}
+        </StyledTypography>
+      </MessageContainer>
+      {fullQuizInfoShown && <StyledDivider variant="fullWidth" />}
+    </>
   )
 }
 
@@ -50,8 +58,7 @@ interface IMessageContainerProps {
 
 const MessageContainer = styled.div<IMessageContainerProps>`
   padding: 1rem;
-  ${({ fullQuizInfoShown }) =>
-    fullQuizInfoShown ? "border-bottom: 3px solid black; " : "height: 400px"}
+  ${({ fullQuizInfoShown }) => (fullQuizInfoShown ? "" : "height: 400px")}
 `
 
 const StyledTypography = styled(Typography)`


### PR DESCRIPTION
Changed the divider from black border to the MUI Divider component with a more subdued look

Before

![image](https://user-images.githubusercontent.com/22303405/63016566-b0afd600-be9c-11e9-8d9c-edf7b2a94cf4.png)


After

![image](https://user-images.githubusercontent.com/22303405/63016478-76463900-be9c-11e9-8059-24d571ff0b38.png)


