### PR TITLE
Points display adjustments

### DIFF
--- a/packages/moocfi-quizzes/example/src/index.tsx
+++ b/packages/moocfi-quizzes/example/src/index.tsx
@@ -78,7 +78,7 @@ const App = () => {
       accessToken={accessToken.value}
       backendAddress={baseUrl.value}
       fullInfoWithoutLogin={showFullInfoWhenLoggedOut === "true"}
-      showAlwaysPointsInfo={showAlwaysPoints === "true"}
+      showZeroPointsInfo={showAlwaysPoints === "true"}
     />
   )
 
@@ -118,7 +118,7 @@ const App = () => {
       />
 
       <StyledFormControlLabel
-        label="Always show points (e.g. scale)"
+        label="Show points info even if quiz points == 1"
         control={
           <Checkbox
             checked={showAlwaysPoints === "true"}

--- a/packages/moocfi-quizzes/src/components/QuizImpl/TopInfoBar.tsx
+++ b/packages/moocfi-quizzes/src/components/QuizImpl/TopInfoBar.tsx
@@ -65,11 +65,9 @@ const TopInfoBar: React.FunctionComponent<ITopInfoBarProps> = ({
   const quiz = useTypedSelector(state => state.quiz)
   const languageInfo = useTypedSelector(state => state.language.languageLabels)
   const displayBars = useTypedSelector(state => state.loadingBars)
-  const alwaysShowPoints = useTypedSelector(
-    state => state.customization.alwaysShowPoints,
+  const showPointsInfo = useTypedSelector(
+    state => state.customization.showPointsInfo,
   )
-
-  const showPointsInfo = alwaysShowPoints
 
   let title
   let quizLabel
@@ -144,11 +142,7 @@ const TopInfoBar: React.FunctionComponent<ITopInfoBarProps> = ({
         </Grid>
       </XXS12Grid>
 
-      {(!quiz ||
-        alwaysShowPoints ||
-        quiz.items.some(
-          qi => qi.type !== "scale" && qi.type !== "checkbox",
-        )) && (
+      {(!quiz || showPointsInfo) && (
         <RightMarginedGrid item={true} xs={2}>
           <PointsLabelText component="div" paragraph={false}>
             {pointsLabel}:

--- a/packages/moocfi-quizzes/src/components/QuizImpl/TopInfoBar.tsx
+++ b/packages/moocfi-quizzes/src/components/QuizImpl/TopInfoBar.tsx
@@ -16,6 +16,10 @@ const PointsText = styled(Typography)`
   font-size: 1.5rem !important;
   text-align: end;
   color: white;
+
+  @media (max-width: 550px) {
+    text-align: start;
+  }
 `
 
 const XXS12Grid = styled(Grid)`
@@ -28,6 +32,11 @@ const XXS12Grid = styled(Grid)`
 const PointsLabelText = styled(Typography)`
   font-size: 1rem !important;
   color: white;
+
+  @media (max-width: 550px) {
+    text-align: start;
+    margin-top: 10px;
+  }
 `
 
 const IconWrapper = styled.div`

--- a/packages/moocfi-quizzes/src/components/QuizImpl/index.tsx
+++ b/packages/moocfi-quizzes/src/components/QuizImpl/index.tsx
@@ -49,7 +49,7 @@ export interface QuizProps {
   backendAddress?: string
   customContent?: Element | JSX.Element
   fullInfoWithoutLogin?: boolean
-  showAlwaysPointsInfo?: boolean
+  showZeroPointsInfo?: boolean
 }
 
 const QuizItemContainerDiv = styled.div`
@@ -97,7 +97,7 @@ const FuncQuizImpl: React.FunctionComponent<QuizProps> = ({
   backendAddress,
   customContent,
   fullInfoWithoutLogin,
-  showAlwaysPointsInfo = true,
+  showZeroPointsInfo = true,
 }) => {
   const submitLocked = useTypedSelector(state => state.quizAnswer.submitLocked)
   const messageState = useTypedSelector(state => state.message)
@@ -106,8 +106,8 @@ const FuncQuizImpl: React.FunctionComponent<QuizProps> = ({
   const languageInfo = useTypedSelector(state => state.language.languageLabels)
   const userQuizState = useTypedSelector(state => state.user.userQuizState)
   const quizDisabled = useTypedSelector(state => state.quizAnswer.quizDisabled)
-  const alwaysShowPoints = useTypedSelector(
-    state => state.customization.alwaysShowPoints,
+  const showPoints = useTypedSelector(
+    state => state.customization.showPointsInfo,
   )
 
   const dispatch = useDispatch()
@@ -123,7 +123,7 @@ const FuncQuizImpl: React.FunctionComponent<QuizProps> = ({
           accessToken,
           backendAddress,
           fullInfoWithoutLogin,
-          showAlwaysPointsInfo,
+          showZeroPointsInfo,
         ),
       )
     },
@@ -209,6 +209,18 @@ const FuncQuizImpl: React.FunctionComponent<QuizProps> = ({
   const containsPeerReviews =
     quiz.peerReviewCollections !== null && quiz.peerReviewCollections.length > 0
 
+  const showPointsPolicyLabel =
+    !quiz.awardPointsEvenIfWrong &&
+    quiz.items.length > 1 &&
+    showPoints &&
+    quiz.items.some(
+      qi =>
+        qi.type !== "checkbox" &&
+        qi.type !== "scale" &&
+        qi.type !== "feedback" &&
+        qi.type !== "research-agreement",
+    )
+
   return (
     <OuterDiv>
       <TopInfoBar />
@@ -275,19 +287,13 @@ const FuncQuizImpl: React.FunctionComponent<QuizProps> = ({
                             }: ${triesRemaining}`
                           : generalLabels.triesNotLimitedLabel}
                       </Typography>
-
-                      {!quiz.awardPointsEvenIfWrong &&
-                        quiz.items.length > 1 &&
-                        (alwaysShowPoints ||
-                          quiz.items.some(
-                            qi => qi.type !== "scale" && qi.type !== "checkbox",
-                          )) && (
-                          <Typography>
-                            {generalLabels.pointsGrantingPolicyInformer(
-                              quiz.grantPointsPolicy,
-                            )}
-                          </Typography>
-                        )}
+                      {showPointsPolicyLabel && (
+                        <Typography>
+                          {generalLabels.pointsGrantingPolicyInformer(
+                            quiz.grantPointsPolicy,
+                          )}
+                        </Typography>
+                      )}
                     </React.Fragment>
                   )}
                 </Grid>

--- a/packages/moocfi-quizzes/src/state/actions.ts
+++ b/packages/moocfi-quizzes/src/state/actions.ts
@@ -22,10 +22,10 @@ export const initialize: ActionCreator<ThunkAction> = (
   accessToken: string,
   backendAddress?: string,
   fullInfoWithoutLogin?: boolean,
-  showAlwaysPointsInfo?: boolean,
+  showZeroPointsInfo?: boolean,
 ) => async (dispatch: Dispatch) => {
-  if (showAlwaysPointsInfo === undefined) {
-    showAlwaysPointsInfo = true
+  if (showZeroPointsInfo === undefined) {
+    showZeroPointsInfo = true
   }
 
   dispatch(clearActionCreator())
@@ -34,7 +34,6 @@ export const initialize: ActionCreator<ThunkAction> = (
   if (backendAddress) {
     dispatch(backendAddressActions.set(backendAddress))
   }
-  dispatch(customizationActions.modify_always_show_points(showAlwaysPointsInfo))
 
   try {
     const fullInfo = !!(accessToken || fullInfoWithoutLogin)
@@ -57,6 +56,12 @@ export const initialize: ActionCreator<ThunkAction> = (
       quizAnswer = loginResponse.quizAnswer
       userQuizState = loginResponse.userQuizState
     }
+
+    dispatch(
+      customizationActions.modify_show_points_info(
+        showZeroPointsInfo || (quiz && quiz.points > 0),
+      ),
+    )
 
     if (!accessToken) {
       dispatch(quizAnswerActions.setQuizDisabled(true))

--- a/packages/moocfi-quizzes/src/state/customization/actions.ts
+++ b/packages/moocfi-quizzes/src/state/customization/actions.ts
@@ -1,6 +1,6 @@
 import { createAction } from "typesafe-actions"
 
-export const modify_always_show_points = createAction(
-  "feedbackDisplayed/MODIFY_ALWAYS_SHOW_POINTS",
+export const modify_show_points_info = createAction(
+  "feedbackDisplayed/MODIFY_SHOW_POINTS_INFO",
   resolve => (newValue: boolean) => resolve(newValue),
 )

--- a/packages/moocfi-quizzes/src/state/customization/reducer.ts
+++ b/packages/moocfi-quizzes/src/state/customization/reducer.ts
@@ -2,11 +2,11 @@ import { ActionType, getType } from "typesafe-actions"
 import * as customization from "./actions"
 
 export interface ICustomizationState {
-  alwaysShowPoints: boolean
+  showPointsInfo: boolean
 }
 
 export const initialState = {
-  alwaysShowPoints: true,
+  showPointsInfo: true,
 }
 
 export const customizationReducer = (
@@ -14,10 +14,10 @@ export const customizationReducer = (
   action: ActionType<typeof customization>,
 ): ICustomizationState => {
   switch (action.type) {
-    case getType(customization.modify_always_show_points):
+    case getType(customization.modify_show_points_info):
       return {
         ...state,
-        alwaysShowPoints: action.payload,
+        showPointsInfo: action.payload,
       }
     default:
       return state

--- a/packages/moocfi-quizzes/src/utils/languages/english_options.ts
+++ b/packages/moocfi-quizzes/src/utils/languages/english_options.ts
@@ -89,7 +89,7 @@ const englishLabels: SingleLanguageLabels = {
         case "grant_only_when_answer_fully_correct":
           return "Answer must be fully correct to receive points"
         case "grant_whenever_possible":
-          return "Partially correct answer may receive some points"
+          return ""
         default:
           return ""
       }

--- a/packages/moocfi-quizzes/src/utils/languages/finnish_options.ts
+++ b/packages/moocfi-quizzes/src/utils/languages/finnish_options.ts
@@ -93,7 +93,7 @@ const finnishLabels: SingleLanguageLabels = {
         case "grant_only_when_answer_fully_correct":
           return "Vastauksen oltava täysin oikein jotta pisteitä voi saada"
         case "grant_whenever_possible":
-          return "Vaillinaisellakin vastauksella voi saada pisteitä"
+          return ""
         default:
           return ""
       }


### PR DESCRIPTION
* Points info in top bar is shown:
  - always if quiz.points > 0
  - if quiz has been given the prop 'showZeroPointsInfo' with the value of 'false'. The default is 'true'

* Info on points grading policy at the bottom of the quiz is shown:
  - if the policy is to only grant any points once all items are correct, AND it is possible to answer at least one item incorrectly (scale, checkbox => always 'correct')
  - the default policy of granting points on a per-item basis is not emphasized with text: in that case, there is no guidance on the grading policy

* Small adjustment to aligning points label and points data in the top bar with small screens