### PR TITLE
Possible to easily write a shared feedback message for all multiple choice items

### DIFF
--- a/packages/backend/src/migration/1567500257341-ModifyTableQuizItemAddColumnUsesSharedOptionFeedbackMessage.ts
+++ b/packages/backend/src/migration/1567500257341-ModifyTableQuizItemAddColumnUsesSharedOptionFeedbackMessage.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner, TableColumn } from "typeorm"
+
+export class ModifyTableQuizItemAddColumnUsesSharedOptionFeedbackMessage1567500257341
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.addColumn(
+      "quiz_item",
+      new TableColumn({
+        name: "uses_shared_option_feedback_message",
+        type: "boolean",
+        default: false,
+      }),
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.dropColumn(
+      "quiz_item",
+      "uses_shared_option_feedback_message",
+    )
+  }
+}

--- a/packages/backend/src/migration/1567500302676-ModifyTableQuizItemTranslationAddColumnSharedOptionFeedbackMessage.ts
+++ b/packages/backend/src/migration/1567500302676-ModifyTableQuizItemTranslationAddColumnSharedOptionFeedbackMessage.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner, TableColumn } from "typeorm"
+
+export class ModifyTableQuizItemTranslationAddColumnSharedOptionFeedbackMessage1567500302676
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.addColumn(
+      "quiz_item_translation",
+      new TableColumn({
+        name: "shared_option_feedback_message",
+        type: "varchar",
+        isNullable: true,
+      }),
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.dropColumn(
+      "quiz_item_translation",
+      "shared_option_feedback_message",
+    )
+  }
+}

--- a/packages/backend/src/models/quiz_item.ts
+++ b/packages/backend/src/models/quiz_item.ts
@@ -77,6 +77,9 @@ export class QuizItem extends BaseEntity {
   @Column({ nullable: true, default: false })
   public multi?: boolean
 
+  @Column({ nullable: false, default: false, select: true })
+  public usesSharedOptionFeedbackMessage: boolean
+
   @CreateDateColumn({ type: "timestamp" })
   public createdAt: Date
   @UpdateDateColumn({ type: "timestamp" })
@@ -150,6 +153,9 @@ export class QuizItemTranslation extends BaseEntity {
   public successMessage?: string
   @Column({ type: "text", nullable: true, select: false })
   public failureMessage?: string
+
+  @Column({ type: "text", nullable: true, select: false })
+  public sharedOptionFeedbackMessage?: string
 
   @CreateDateColumn({ type: "timestamp" })
   public createdAt: Date

--- a/packages/backend/src/models/quiz_item.ts
+++ b/packages/backend/src/models/quiz_item.ts
@@ -154,7 +154,7 @@ export class QuizItemTranslation extends BaseEntity {
   @Column({ type: "text", nullable: true, select: false })
   public failureMessage?: string
 
-  @Column({ type: "text", nullable: true, select: false })
+  @Column({ type: "text", nullable: true })
   public sharedOptionFeedbackMessage?: string
 
   @CreateDateColumn({ type: "timestamp" })

--- a/packages/dashboard/src/components/MultipleChoice/ExpandedMultipleChoiceItem.tsx
+++ b/packages/dashboard/src/components/MultipleChoice/ExpandedMultipleChoiceItem.tsx
@@ -21,6 +21,7 @@ import {
 import BottomActionsExpItem from "../ItemTools/ExpandedBottomActions"
 import ExpandedTopInformation from "../ItemTools/ExpandedTopInformation"
 import OptionDialog from "../OptionDialog"
+import SharedFeedbackCustomiser from "./SharedFeedbackCustomiser"
 import SortableOptionList from "./SortableOptionList"
 
 interface IExpandedMultipleChoiceItemProps {
@@ -47,6 +48,8 @@ interface IItemData {
   title: string
   body: string
   options: IOptionData[]
+  sharedFeedbackMessageIsUsed: boolean
+  sharedFeedbackMessage: string
 }
 
 export interface IOptionData {
@@ -84,6 +87,8 @@ class MultipleChoiceItem extends React.Component<
       title: item.texts[0].title,
       body: item.texts[0].body,
       options: initOptionsData,
+      sharedFeedbackMessageIsUsed: true,
+      sharedFeedbackMessage: "Yeet",
     }
     this.state = {
       dialogOpen: false,
@@ -179,6 +184,22 @@ class MultipleChoiceItem extends React.Component<
                         </Grid>
                       )}
                     </Grid>
+                    <Grid item={true} xs={12}>
+                      <SharedFeedbackCustomiser
+                        sharedMessageIsUsed={
+                          this.state.tempItemData.sharedFeedbackMessageIsUsed
+                        }
+                        sharedFeedbackMessage={
+                          this.state.tempItemData.sharedFeedbackMessage
+                        }
+                        handleToggleChange={this.changeEditAttribute(
+                          "sharedFeedbackMessageIsUsed",
+                        )}
+                        handleMessageChange={this.changeEditAttribute(
+                          "sharedFeedbackMessage",
+                        )}
+                      />
+                    </Grid>
                   </Grid>
                 </CardContent>
               </Grid>
@@ -216,7 +237,11 @@ class MultipleChoiceItem extends React.Component<
       })
     }
     const newData = { ...this.state.tempItemData }
-    newData[attributeName] = e.target.value
+    if (attributeName === "sharedFeedbackMessageIsUsed") {
+      newData[attributeName] = !newData[attributeName]
+    } else {
+      newData[attributeName] = e.target.value
+    }
     this.setState({ tempItemData: newData })
   }
 

--- a/packages/dashboard/src/components/MultipleChoice/ExpandedMultipleChoiceItem.tsx
+++ b/packages/dashboard/src/components/MultipleChoice/ExpandedMultipleChoiceItem.tsx
@@ -48,8 +48,8 @@ interface IItemData {
   title: string
   body: string
   options: IOptionData[]
-  sharedFeedbackMessageIsUsed: boolean
-  sharedFeedbackMessage: string
+  usesSharedOptionFeedbackMessage: boolean
+  sharedOptionFeedbackMessage: string
 }
 
 export interface IOptionData {
@@ -87,8 +87,9 @@ class MultipleChoiceItem extends React.Component<
       title: item.texts[0].title,
       body: item.texts[0].body,
       options: initOptionsData,
-      sharedFeedbackMessageIsUsed: true,
-      sharedFeedbackMessage: "Yeet",
+      usesSharedOptionFeedbackMessage: item.usesSharedOptionFeedbackMessage,
+      sharedOptionFeedbackMessage:
+        item.texts[0].sharedOptionFeedbackMessage || "",
     }
     this.state = {
       dialogOpen: false,
@@ -187,16 +188,17 @@ class MultipleChoiceItem extends React.Component<
                     <Grid item={true} xs={12}>
                       <SharedFeedbackCustomiser
                         sharedMessageIsUsed={
-                          this.state.tempItemData.sharedFeedbackMessageIsUsed
+                          this.state.tempItemData
+                            .usesSharedOptionFeedbackMessage
                         }
                         sharedFeedbackMessage={
-                          this.state.tempItemData.sharedFeedbackMessage
+                          this.state.tempItemData.sharedOptionFeedbackMessage
                         }
                         handleToggleChange={this.changeEditAttribute(
-                          "sharedFeedbackMessageIsUsed",
+                          "usesSharedOptionFeedbackMessage",
                         )}
                         handleMessageChange={this.changeEditAttribute(
-                          "sharedFeedbackMessage",
+                          "sharedOptionFeedbackMessage",
                         )}
                       />
                     </Grid>
@@ -237,7 +239,7 @@ class MultipleChoiceItem extends React.Component<
       })
     }
     const newData = { ...this.state.tempItemData }
-    if (attributeName === "sharedFeedbackMessageIsUsed") {
+    if (attributeName === "usesSharedOptionFeedbackMessage") {
       newData[attributeName] = !newData[attributeName]
     } else {
       newData[attributeName] = e.target.value
@@ -255,6 +257,16 @@ class MultipleChoiceItem extends React.Component<
     this.props.changeAttr(
       `items[${this.props.order}].texts[0].body`,
       this.state.tempItemData.body,
+    )
+
+    this.props.changeAttr(
+      `items[${this.props.order}].texts[0].sharedOptionFeedbackMessage`,
+      this.state.tempItemData.sharedOptionFeedbackMessage,
+    )
+
+    this.props.changeAttr(
+      `items[${this.props.order}].usesSharedOptionFeedbackMessage`,
+      this.state.tempItemData.usesSharedOptionFeedbackMessage,
     )
 
     this.props.updateMultipleOptions(

--- a/packages/dashboard/src/components/MultipleChoice/SharedFeedbackCustomiser.tsx
+++ b/packages/dashboard/src/components/MultipleChoice/SharedFeedbackCustomiser.tsx
@@ -16,6 +16,7 @@ const SharedFeedbackCustomiser: React.FunctionComponent<
   handleMessageChange,
   handleToggleChange,
 }) => {
+  console.log("Mesage used: ", sharedMessageIsUsed)
   return (
     <>
       <FormControlLabel
@@ -26,14 +27,16 @@ const SharedFeedbackCustomiser: React.FunctionComponent<
             onChange={handleToggleChange}
           />
         }
-        label="Set a shared feedback message for all options"
+        label="Set a shared feedback message for all options. Overrides feedback message of every option."
       />
 
       <Grow
-        // style={{ transformOrigin: "right center" }}
-        style={{ width: "100%" }}
+        style={{
+          display: sharedMessageIsUsed ? "inline-flex" : "none",
+          width: "100%",
+          marginTop: "1rem",
+        }}
         in={sharedMessageIsUsed}
-        // btimeout={deadlineChecked && shouldAnimateTextField ? 500 : 0}
       >
         <TextField
           variant="outlined"

--- a/packages/dashboard/src/components/MultipleChoice/SharedFeedbackCustomiser.tsx
+++ b/packages/dashboard/src/components/MultipleChoice/SharedFeedbackCustomiser.tsx
@@ -1,0 +1,50 @@
+import { Checkbox, FormControlLabel, Grow, TextField } from "@material-ui/core"
+import * as React from "react"
+
+interface ISharedFeedbackCustomiserProps {
+  sharedMessageIsUsed: boolean
+  sharedFeedbackMessage: string
+  handleToggleChange: (e: any) => void
+  handleMessageChange: (e: any) => void
+}
+
+const SharedFeedbackCustomiser: React.FunctionComponent<
+  ISharedFeedbackCustomiserProps
+> = ({
+  sharedMessageIsUsed,
+  sharedFeedbackMessage,
+  handleMessageChange,
+  handleToggleChange,
+}) => {
+  return (
+    <>
+      <FormControlLabel
+        control={
+          <Checkbox
+            checked={sharedMessageIsUsed}
+            color="primary"
+            onChange={handleToggleChange}
+          />
+        }
+        label="Set a shared feedback message for all options"
+      />
+
+      <Grow
+        // style={{ transformOrigin: "right center" }}
+        style={{ width: "100%" }}
+        in={sharedMessageIsUsed}
+        // btimeout={deadlineChecked && shouldAnimateTextField ? 500 : 0}
+      >
+        <TextField
+          variant="outlined"
+          value={sharedFeedbackMessage}
+          onChange={handleMessageChange}
+          multiline={true}
+          type="text"
+        />
+      </Grow>
+    </>
+  )
+}
+
+export default SharedFeedbackCustomiser

--- a/packages/dashboard/src/components/OptionDialog.tsx
+++ b/packages/dashboard/src/components/OptionDialog.tsx
@@ -176,6 +176,9 @@ export default class OptionDialog extends React.Component<
                   value={this.state.optionData.message}
                   onChange={this.handleTextFieldChange("message")}
                 />
+                <Typography variant="body1" style={{ padding: "5px 0" }}>
+                  The student won't see this before completing the exercise.
+                </Typography>
               </Grid>
             </Grid>
           </FormGroup>

--- a/packages/dashboard/src/interfaces.ts
+++ b/packages/dashboard/src/interfaces.ts
@@ -68,6 +68,7 @@ export interface IQuizItemText {
   failureMessage: string
   minLabel: string
   maxLabel: string
+  sharedOptionFeedbackMessage?: string
 }
 
 export interface IQuizItem {
@@ -84,6 +85,7 @@ export interface IQuizItem {
   multi: boolean
   texts: IQuizItemText[]
   options: IQuizItemOption[]
+  usesSharedOptionFeedbackMessage: boolean
 }
 
 export interface ICourseText {

--- a/packages/moocfi-quizzes/src/components/MultipleChoice.tsx
+++ b/packages/moocfi-quizzes/src/components/MultipleChoice.tsx
@@ -472,20 +472,28 @@ const FeedbackPortion: React.FunctionComponent<IFeedbackPortionProps> = ({
   const onlyOneItem = items.length === 1
   const generalLabels = languageLabels.general
 
-  const optionSuccess = selectedOption
-    ? selectedOption.texts[0].successMessage
-    : undefined
-  const optionFailure = selectedOption
-    ? selectedOption.texts[0].failureMessage
-    : undefined
+  let feedbackMessage
+  if (
+    item.usesSharedOptionFeedbackMessage &&
+    item.texts[0].sharedOptionFeedbackMessage !== undefined
+  ) {
+    feedbackMessage = item.texts[0].sharedOptionFeedbackMessage
+  } else {
+    const optionSuccess = selectedOption
+      ? selectedOption.texts[0].successMessage
+      : undefined
+    const optionFailure = selectedOption
+      ? selectedOption.texts[0].failureMessage
+      : undefined
 
-  const text = item.texts[0]
-  const successMessage =
-    optionSuccess || text.successMessage || generalLabels.answerCorrectLabel
-  const failureMessage =
-    optionFailure || text.failureMessage || generalLabels.answerIncorrectLabel
+    const text = item.texts[0]
+    const successMessage =
+      optionSuccess || text.successMessage || generalLabels.answerCorrectLabel
+    const failureMessage =
+      optionFailure || text.failureMessage || generalLabels.answerIncorrectLabel
 
-  const feedbackMessage = itemAnswer.correct ? successMessage : failureMessage
+    feedbackMessage = itemAnswer.correct ? successMessage : failureMessage
+  }
 
   const feedbackColor = itemAnswer.correct ? "#047500" : "#DB0000"
 

--- a/packages/moocfi-quizzes/src/modelTypes.ts
+++ b/packages/moocfi-quizzes/src/modelTypes.ts
@@ -117,6 +117,7 @@ export type QuizItemText = {
   failureMessage: string
   minLabel: string
   maxLabel: string
+  sharedOptionFeedbackMessage?: string
 }
 
 export type QuizItem = {
@@ -129,6 +130,7 @@ export type QuizItem = {
   minValue: number
   maxValue: number
   formatRegex: string
+  usesSharedOptionFeedbackMessage: boolean
   multi: boolean
   texts: QuizItemText[]
   options: QuizItemOption[]


### PR DESCRIPTION
## Changes in backend

* Quiz Item received a new  boolean column 'uses_shared_option_feedback_message' that is false by default
* Quiz Item Translation received a new nullable text column 'shared_option_feedback_message'.

## Changes in dashboard
* Multiple choice item received a new checkbox for changing whether a  shared message should be used, and a text field that appears when the box is checked.
* Added a short guidance text for feedback message while in the option editing view (to emphasize that the message is not visible before the exercise has been completed)

![image](https://user-images.githubusercontent.com/22303405/64167107-30541380-ce51-11e9-9eae-9c739e9191c7.png)

![shared_messge_example](https://user-images.githubusercontent.com/22303405/64167151-49f55b00-ce51-11e9-8d50-765c19e95dc0.png)

## Changes in widgets 
* If a multiple choice quiz item has true in  'uses_shared_option_feedback_message' and the message is set, that message is displayed as the feedback message regardless of the texts of the option
