### PR TITLE
Clearer state after submitting incorrect answer, tries remaining

### DIFF
--- a/packages/moocfi-quizzes/src/state/message/actions.ts
+++ b/packages/moocfi-quizzes/src/state/message/actions.ts
@@ -19,19 +19,28 @@ export const clearErrorMessage = createAction("message/CLEAR_ERROR_MESSAGE")
 export const setNotification = createAction(
   "message/SET_NOTIFICATION",
   resolve => {
-    return (message: string, color: string = "black") =>
-      resolve({ message, color })
+    return (
+      message: string,
+      color: string = "black",
+      untilAnswerChanged: boolean = false,
+    ) => resolve({ message, color, untilAnswerChanged })
   },
 )
 
+export const answerWasChanged = createAction("message/ANSWER_WAS_CHANGED")
+
 export const clearNotification = createAction("message/CLEAR_NOTIFICATION")
 
+// if length in seconds and untilAnswerChanged both not null,
+// the notification will disappear when the first of the events
+// occurs
 export const displayNotification: ActionCreator<ThunkAction> = (
   message: string,
   color: string,
   lengthInSeconds?: number,
+  untilAnswerChanged?: boolean,
 ) => async dispatch => {
-  dispatch(setNotification(message, color))
+  dispatch(setNotification(message, color, !!untilAnswerChanged))
 
   if (lengthInSeconds) {
     setTimeout(() => dispatch(clearNotification()), 1000 * lengthInSeconds)

--- a/packages/moocfi-quizzes/src/state/message/reducer.ts
+++ b/packages/moocfi-quizzes/src/state/message/reducer.ts
@@ -4,6 +4,7 @@ import * as message from "./actions"
 export const initialState = {
   errorMessage: null,
   notification: null,
+  notificationDisplayedUntilAnswerChanges: false,
 }
 
 export type MessageState = {
@@ -12,6 +13,7 @@ export type MessageState = {
     message: string
     color: string
   } | null
+  notificationDisplayedUntilAnswerChanges: boolean
 }
 
 export const messageReducer = (
@@ -24,6 +26,15 @@ export const messageReducer = (
         ...state,
         errorMessage: action.payload,
       }
+    case getType(message.answerWasChanged):
+      if (state.notificationDisplayedUntilAnswerChanges) {
+        return {
+          ...state,
+          notification: null,
+          notificationDisplayedUntilAnswerChanges: false,
+        }
+      }
+      return state
     case getType(message.setNotification):
       return {
         ...state,
@@ -31,6 +42,8 @@ export const messageReducer = (
           message: action.payload.message,
           color: action.payload.color,
         },
+        notificationDisplayedUntilAnswerChanges:
+          action.payload.untilAnswerChanged,
       }
     case getType(message.clearErrorMessage):
       return {

--- a/packages/moocfi-quizzes/src/state/quizAnswer/actions.ts
+++ b/packages/moocfi-quizzes/src/state/quizAnswer/actions.ts
@@ -45,23 +45,32 @@ export const changeTextDataAction = createAction(
     resolve({ itemId, newValue, readyToSubmit }),
 )
 
-export const changeIntData = createAction(
+export const changeIntDataAction = createAction(
   "quizAnswer/UPDATE_INT_VALUE",
   resolve => (itemId: string, newValue: number) =>
     resolve({ itemId, newValue }),
 )
 
-export const changeCheckboxData = createAction(
+export const changeCheckboxDataAction = createAction(
   "quizAnswer/TOGGLE_CHECKBOX_VALUE",
   resolve => (itemId: string, optionId: string) =>
     resolve({ itemId, optionId }),
 )
 
-export const chooseOption = createAction(
+export const chooseOptionAction = createAction(
   "quizAnswer/CHOOSE_OPTION",
   resolve => (itemId: string, optionId: string, multi: boolean) =>
     resolve({ itemId, optionId, multi }),
 )
+
+export const chooseOption: ActionCreator<ThunkAction> = (
+  itemId: string,
+  optionId: string,
+  multi: boolean,
+) => (dispatch, getState) => {
+  dispatch(messageActions.answerWasChanged())
+  dispatch(chooseOptionAction(itemId, optionId, multi))
+}
 
 export const changeChosenOption: ActionCreator<ThunkAction> = (
   itemId: string,
@@ -72,8 +81,17 @@ export const changeChosenOption: ActionCreator<ThunkAction> = (
     return
   }
   const multi = item.multi
+  dispatch(messageActions.answerWasChanged())
   dispatch(feedbackDisplayedActions.hide())
   dispatch(chooseOption(itemId, optionId, multi))
+}
+
+export const changeCheckboxData: ActionCreator<ThunkAction> = (
+  itemId: string,
+  optionId: string,
+) => (dispatch, getState) => {
+  dispatch(messageActions.answerWasChanged())
+  dispatch(changeCheckboxDataAction(itemId, optionId))
 }
 
 export const noticeDisabledSubmitAttempt: ActionCreator<ThunkAction> = () => (
@@ -84,6 +102,14 @@ export const noticeDisabledSubmitAttempt: ActionCreator<ThunkAction> = () => (
   setTimeout(() => dispatch(clearAttemptedSubmit()), 5000)
 }
 
+export const changeIntData: ActionCreator<ThunkAction> = (
+  itemId: string,
+  newValue: number,
+) => (dispatch, getState) => {
+  dispatch(messageActions.answerWasChanged())
+  dispatch(changeIntDataAction(itemId, newValue))
+}
+
 export const changeTextData: ActionCreator<ThunkAction> = (
   itemId: string,
   newValue: string,
@@ -92,6 +118,7 @@ export const changeTextData: ActionCreator<ThunkAction> = (
   if (item === undefined) {
     return
   }
+  dispatch(messageActions.answerWasChanged())
   dispatch(feedbackDisplayedActions.hide())
   const readyToSubmit = itemAnswerReadyForSubmit(newValue, item)
   dispatch(changeTextDataAction(itemId, newValue, readyToSubmit))
@@ -135,7 +162,8 @@ export const submit: ActionCreator<ThunkAction> = () => async (
         messageActions.displayNotification(
           languageInfo.general.incorrectSubmitWhileTriesLeftLabel,
           "red",
-          5,
+          60 * 60 * 24,
+          true,
         ),
       )
     }

--- a/packages/moocfi-quizzes/src/state/quizAnswer/reducer.ts
+++ b/packages/moocfi-quizzes/src/state/quizAnswer/reducer.ts
@@ -61,7 +61,7 @@ export const quizAnswerReducer = (
       return { ...state, attemptedDisabledSubmit: true }
     case getType(quizAnswer.clearAttemptedSubmit):
       return { ...state, attemptedDisabledSubmit: false }
-    case getType(quizAnswer.changeIntData):
+    case getType(quizAnswer.changeIntDataAction):
       newItemAnswersReady = { ...state.itemAnswersReady }
       newItemAnswersReady[`${action.payload.itemId}`] = true
       return {
@@ -101,7 +101,7 @@ export const quizAnswerReducer = (
         noChangesAfterLoading: false,
       }
 
-    case getType(quizAnswer.changeCheckboxData):
+    case getType(quizAnswer.changeCheckboxDataAction):
       newItemAnswersReady = { ...state.itemAnswersReady }
       newItemAnswersReady[`${action.payload.itemId}`] = true
 
@@ -133,7 +133,7 @@ export const quizAnswerReducer = (
         noChangesSinceSuccessfulSubmit: false,
         noChangesAfterLoading: false,
       }
-    case getType(quizAnswer.chooseOption):
+    case getType(quizAnswer.chooseOptionAction):
       newItemAnswersReady = { ...state.itemAnswersReady }
       newItemAnswersReady[`${action.payload.itemId}`] = true
 

--- a/packages/moocfi-quizzes/src/utils/languages/english_options.ts
+++ b/packages/moocfi-quizzes/src/utils/languages/english_options.ts
@@ -82,7 +82,7 @@ const englishLabels: SingleLanguageLabels = {
     quizLabel: "Quiz",
     pointsLabel: "Points",
     triesNotLimitedLabel: "Number of tries is unlimited",
-    submitGeneralFeedbackLabel: "Submit successful",
+    submitGeneralFeedbackLabel: "Submitted",
     submitButtonAlreadyAnsweredLabel: "Answered",
     pointsGrantingPolicyInformer: policy => {
       switch (policy) {

--- a/packages/moocfi-quizzes/src/utils/languages/finnish_options.ts
+++ b/packages/moocfi-quizzes/src/utils/languages/finnish_options.ts
@@ -86,7 +86,7 @@ const finnishLabels: SingleLanguageLabels = {
     quizLabel: "Kysely",
     pointsLabel: "Pisteitä",
     triesNotLimitedLabel: "Yritysten lukumäärää ei rajattu",
-    submitGeneralFeedbackLabel: "Vastattu onnistuneesti",
+    submitGeneralFeedbackLabel: "Vastattu",
     submitButtonAlreadyAnsweredLabel: "Vastattu",
     pointsGrantingPolicyInformer: policy => {
       switch (policy) {


### PR DESCRIPTION
Added option to display message until the first change after a submit attempt. This is used when displaying the
message that the answer has been submitted, but it was not correct. Also, the button only displays 'submitted',
not 'submitted successfully' (and the same in Finnish).

At some point this functionality will have to be placed inside the reducers of the store, not action creators (now quick fix was prioritised).