### PR TITLE
Changing max points from 0p quiz does not divide by zero

### DIFF
--- a/packages/backend/src/services/userquizstate.service.ts
+++ b/packages/backend/src/services/userquizstate.service.ts
@@ -170,10 +170,13 @@ export default class UserQuizStateService {
 
     const query = this.knex("user_quiz_state")
       .update({
-        points_awarded: this.knex.raw(
-          "(points_awarded * :maxPoints / :oldMaxPoints)",
-          { maxPoints, oldMaxPoints },
-        ),
+        points_awarded:
+          oldMaxPoints === 0
+            ? this.knex.raw(":maxPoints", { maxPoints })
+            : this.knex.raw("(points_awarded * :maxPoints / :oldMaxPoints)", {
+                maxPoints,
+                oldMaxPoints,
+              }),
       })
       .where({ quiz_id: quiz.id })
 


### PR DESCRIPTION
If the quiz has had 0 max points, we'll give everyone who answered it full points. 
A few issues remain with this scaling approach from the previous user quiz state: 
* If someone accidentally changes the max points to zero at some point, everyone who answered will get full points after the next change (e.g. 
```
 max 3p, answers [0, 1, 2, 2, 3, 3, 2] 
-> max 0p, answers [0, 0, 0, 0, 0, 0, 0]
-> max 3p, answers [3, 3, 3, 3, 3, 3, 3]
```
).

* Should change to recalculating the user quiz state based on the quiz answer? Downside: more processing time and queries... The 'recalculate all answers' button to the dashboard would still be useful