### PR TITLE
Multiple choice can be configured to require choosing all the correct answers

### DIFF
--- a/packages/dashboard/src/components/MultipleChoice/ExpandedMultipleChoiceItem.tsx
+++ b/packages/dashboard/src/components/MultipleChoice/ExpandedMultipleChoiceItem.tsx
@@ -21,6 +21,7 @@ import {
 import BottomActionsExpItem from "../ItemTools/ExpandedBottomActions"
 import ExpandedTopInformation from "../ItemTools/ExpandedTopInformation"
 import OptionDialog from "../OptionDialog"
+import MultiToggle from "./MultiToggle"
 import SharedFeedbackCustomiser from "./SharedFeedbackCustomiser"
 import SortableOptionList from "./SortableOptionList"
 
@@ -50,6 +51,7 @@ interface IItemData {
   options: IOptionData[]
   usesSharedOptionFeedbackMessage: boolean
   sharedOptionFeedbackMessage: string
+  multi: boolean
 }
 
 export interface IOptionData {
@@ -90,6 +92,7 @@ class MultipleChoiceItem extends React.Component<
       usesSharedOptionFeedbackMessage: item.usesSharedOptionFeedbackMessage,
       sharedOptionFeedbackMessage:
         item.texts[0].sharedOptionFeedbackMessage || "",
+      multi: item.multi,
     }
     this.state = {
       dialogOpen: false,
@@ -202,6 +205,13 @@ class MultipleChoiceItem extends React.Component<
                         )}
                       />
                     </Grid>
+
+                    <Grid item={true} xs={12}>
+                      <MultiToggle
+                        multi={this.state.tempItemData.multi}
+                        toggleMulti={this.changeEditAttribute("multi")}
+                      />
+                    </Grid>
                   </Grid>
                 </CardContent>
               </Grid>
@@ -239,7 +249,10 @@ class MultipleChoiceItem extends React.Component<
       })
     }
     const newData = { ...this.state.tempItemData }
-    if (attributeName === "usesSharedOptionFeedbackMessage") {
+    if (
+      attributeName === "usesSharedOptionFeedbackMessage" ||
+      attributeName === "multi"
+    ) {
       newData[attributeName] = !newData[attributeName]
     } else {
       newData[attributeName] = e.target.value
@@ -250,24 +263,28 @@ class MultipleChoiceItem extends React.Component<
   private saveItem = e => {
     this.props.toggleExpand(e)
 
+    const itemsString = `items[${this.props.order}]`
+
     this.props.changeAttr(
-      `items[${this.props.order}].texts[0].title`,
+      `${itemsString}.texts[0].title`,
       this.state.tempItemData.title,
     )
     this.props.changeAttr(
-      `items[${this.props.order}].texts[0].body`,
+      `${itemsString}.texts[0].body`,
       this.state.tempItemData.body,
     )
 
     this.props.changeAttr(
-      `items[${this.props.order}].texts[0].sharedOptionFeedbackMessage`,
+      `${itemsString}.texts[0].sharedOptionFeedbackMessage`,
       this.state.tempItemData.sharedOptionFeedbackMessage,
     )
 
     this.props.changeAttr(
-      `items[${this.props.order}].usesSharedOptionFeedbackMessage`,
+      `${itemsString}.usesSharedOptionFeedbackMessage`,
       this.state.tempItemData.usesSharedOptionFeedbackMessage,
     )
+
+    this.props.changeAttr(`${itemsString}.multi`, this.state.tempItemData.multi)
 
     this.props.updateMultipleOptions(
       this.props.order,

--- a/packages/dashboard/src/components/MultipleChoice/MultiToggle.tsx
+++ b/packages/dashboard/src/components/MultipleChoice/MultiToggle.tsx
@@ -17,22 +17,6 @@ const MultiToggle: React.FunctionComponent<IMultiToggleProps> = ({
       }
       label="Answerer should choose all the correct options"
     />
-
-    <Grow
-      style={{
-        display: multi ? "inline-flex" : "none",
-        width: "100%",
-        marginTop: "1rem",
-      }}
-      in={multi}
-    >
-      <TextField
-        variant="outlined"
-        placeholder="Grading policy (this does nothing at the moment you can write anything)"
-        multiline={true}
-        type="text"
-      />
-    </Grow>
   </>
 )
 

--- a/packages/dashboard/src/components/MultipleChoice/MultiToggle.tsx
+++ b/packages/dashboard/src/components/MultipleChoice/MultiToggle.tsx
@@ -1,0 +1,39 @@
+import { Checkbox, FormControlLabel, Grow, TextField } from "@material-ui/core"
+import React from "react"
+
+interface IMultiToggleProps {
+  multi: boolean
+  toggleMulti: (e: any) => void
+}
+
+const MultiToggle: React.FunctionComponent<IMultiToggleProps> = ({
+  multi,
+  toggleMulti,
+}) => (
+  <>
+    <FormControlLabel
+      control={
+        <Checkbox checked={multi} color="primary" onChange={toggleMulti} />
+      }
+      label="Answerer should choose all the correct options"
+    />
+
+    <Grow
+      style={{
+        display: multi ? "inline-flex" : "none",
+        width: "100%",
+        marginTop: "1rem",
+      }}
+      in={multi}
+    >
+      <TextField
+        variant="outlined"
+        placeholder="Grading policy (this does nothing at the moment you can write anything)"
+        multiline={true}
+        type="text"
+      />
+    </Grow>
+  </>
+)
+
+export default MultiToggle

--- a/packages/dashboard/src/components/MultipleChoice/SharedFeedbackCustomiser.tsx
+++ b/packages/dashboard/src/components/MultipleChoice/SharedFeedbackCustomiser.tsx
@@ -16,7 +16,6 @@ const SharedFeedbackCustomiser: React.FunctionComponent<
   handleMessageChange,
   handleToggleChange,
 }) => {
-  console.log("Mesage used: ", sharedMessageIsUsed)
   return (
     <>
       <FormControlLabel

--- a/packages/dashboard/src/components/MultipleChoice/ShortMultipleChoiceItem.tsx
+++ b/packages/dashboard/src/components/MultipleChoice/ShortMultipleChoiceItem.tsx
@@ -29,6 +29,11 @@ class FinishedMultipleChoiceItem extends React.Component<any, any> {
             >
               {item.texts[0].title}
             </Typography>
+            {item.multi && (
+              <Typography variant="subtitle1">
+                All the correct options must be chosen
+              </Typography>
+            )}
           </Grid>
 
           <Grid item={true} xs={6} lg={8}>
@@ -71,11 +76,6 @@ class FinishedMultipleChoiceItem extends React.Component<any, any> {
             </Grid>
           </Grid>
         </Grid>
-        {item.multi && (
-          <Typography variant="subtitle1">
-            Answerers can choose multiple options
-          </Typography>
-        )}
       </ShortWrapper>
     )
   }

--- a/packages/dashboard/src/components/MultipleChoice/ShortMultipleChoiceItem.tsx
+++ b/packages/dashboard/src/components/MultipleChoice/ShortMultipleChoiceItem.tsx
@@ -71,6 +71,11 @@ class FinishedMultipleChoiceItem extends React.Component<any, any> {
             </Grid>
           </Grid>
         </Grid>
+        {item.multi && (
+          <Typography variant="subtitle1">
+            Answerers can choose multiple options
+          </Typography>
+        )}
       </ShortWrapper>
     )
   }


### PR DESCRIPTION
If the checkbox is selected, the multiple choice quiz item only grants points when ALL the correct answers are selected. Support already existed in the widgets and the backend, so just added the possibility to configure to the dashboard and tested that the whole process works.