### PR TITLE
Changed route for requesting user roles

### DIFF
--- a/packages/backend/src/controllers/usercourserole/index.ts
+++ b/packages/backend/src/controllers/usercourserole/index.ts
@@ -6,7 +6,7 @@ import { InjectManager } from "typeorm-typedi-extensions"
 import { API_PATH } from "../../config"
 import { ITMCProfileDetails } from "../../types"
 
-@JsonController(`${API_PATH}/quizzes/usercourserole`)
+@JsonController(`${API_PATH}/usercourseroles`)
 export class UserCourseRoleController {
   @InjectManager()
   private entityManager: EntityManager

--- a/packages/dashboard/src/services/roles.ts
+++ b/packages/dashboard/src/services/roles.ts
@@ -4,7 +4,7 @@ import { IUserCourseRole } from "../interfaces"
 export const getOwnRoles = async (
   accessToken: string,
 ): Promise<IUserCourseRole[]> => {
-  const response = await axios.get(`/api/v1/quizzes/usercourserole`, {
+  const response = await axios.get(`/api/v1/usercourseroles`, {
     headers: { authorization: `Bearer ${accessToken}` },
   })
 


### PR DESCRIPTION
Avoiding route overlap between /quizzes/:id and quizzes/usercourserole