### PR TITLE
Changes in review process

### DIFF
--- a/packages/backend/src/controllers/peerreviews/index.ts
+++ b/packages/backend/src/controllers/peerreviews/index.ts
@@ -142,7 +142,13 @@ export class PeerReviewController {
       {
         userId: peerReview.userId,
         quizId: receivingQuizAnswer.quizId,
-        statuses: ["confirmed", "submitted", "enough-received-but-not-given"],
+        statuses: [
+          "confirmed",
+          "submitted",
+          "enough-received-but-not-given",
+          // receiving 1 spam flag could make status 'manual-review'
+          "manual-review",
+        ],
       },
       this.entityManager,
     )

--- a/packages/backend/src/controllers/quizanswers/index.ts
+++ b/packages/backend/src/controllers/quizanswers/index.ts
@@ -289,15 +289,7 @@ export class QuizAnswerController {
       attentionCriteriaQuery.quizRequiresPeerReviews = true
 
       if (course.texts[0].abbreviation.includes("elements-of-ai")) {
-        attentionCriteriaQuery.statuses = [
-          "spam",
-          "submitted",
-          "enough-received-but-not-given",
-        ]
-        attentionCriteriaQuery.minPeerReviewsGiven = course.minPeerReviewsGiven
-        attentionCriteriaQuery.minPeerReviewsReceived =
-          course.minPeerReviewsReceived
-        attentionCriteriaQuery.minSpamFlagsOr = 1
+        attentionCriteriaQuery.statuses = ["manual-review"]
       } else {
         const limitDate = new Date()
         limitDate.setDate(limitDate.getDate() - 14)

--- a/packages/backend/src/migration/1584046882222-add_value_manual_review_to_quiz_answer_status_enum.ts
+++ b/packages/backend/src/migration/1584046882222-add_value_manual_review_to_quiz_answer_status_enum.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class addValueManualReviewToQuizAnswerStatusEnum1584046882222
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(
+      // tslint:disable-next-line:max-line-length
+      "create type quiz_answer_status_enum_new as enum ('draft', 'submitted', 'enough-received-but-not-given', 'confirmed', 'spam', 'rejected', 'deprecated', 'manual-review')",
+    )
+    await queryRunner.query(
+      // tslint:disable-next-line:max-line-length
+      "alter table quiz_answer alter column status set data type quiz_answer_status_enum_new using (status::text::quiz_answer_status_enum_new)",
+    )
+    await queryRunner.query("drop type quiz_answer_status_enum")
+    await queryRunner.query(
+      "alter type quiz_answer_status_enum_new rename to quiz_answer_status_enum",
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(
+      // tslint:disable-next-line:max-line-length
+      "create type quiz_answer_status_enum_rollback as enum ('draft', 'submitted', 'enough-received-but-not-given', 'spam', 'confirmed', 'rejected', 'deprecated')",
+    )
+    await queryRunner.query(
+      // tslint:disable-next-line:max-line-length
+      "alter table quiz_answer alter column status set data type quiz_answer_status_enum_rollback using (status::text::quiz_answer_status_enum_rollback)",
+    )
+    await queryRunner.query("drop type quiz_answer_status_enum")
+    await queryRunner.query(
+      "alter type quiz_answer_status_enum_rollback rename to quiz_answer_status_enum",
+    )
+  }
+}

--- a/packages/backend/src/models/quiz_answer.ts
+++ b/packages/backend/src/models/quiz_answer.ts
@@ -45,10 +45,11 @@ export class QuizAnswer extends BaseEntity {
       "draft",
       "submitted",
       "enough-received-but-not-given",
-      "spam",
       "confirmed",
+      "spam",
       "rejected",
       "deprecated",
+      "manual-review",
     ],
   })
   public status?: string

--- a/packages/backend/src/services/peerreview.service.ts
+++ b/packages/backend/src/services/peerreview.service.ts
@@ -319,6 +319,11 @@ export default class PeerReviewService {
           qb.whereNull("points_awarded")
             .andWhere(
               builder.raw(
+                "peer_reviews_given >= course.min_peer_reviews_given",
+              ),
+            )
+            .andWhere(
+              builder.raw(
                 "peer_reviews_received < course.min_peer_reviews_received",
               ),
             )

--- a/packages/backend/src/services/quizanswer.service.ts
+++ b/packages/backend/src/services/quizanswer.service.ts
@@ -197,10 +197,7 @@ export default class QuizAnswerService {
         elementsCriteria = {
           courseIds: elementsCourseIds,
           courseIdIncludedInCourseIds: true,
-          statuses: ["spam", "submitted", "enough-received-but-not-given"],
-          minPeerReviewsGiven: 3,
-          minPeerReviewsReceived: 2,
-          minSpamFlagsOr: 1,
+          statuses: ["manual-review"],
         }
         elementsCriteria.courseIdIncludedInCourseIds = true
       }

--- a/packages/backend/src/services/quizanswer.service.ts
+++ b/packages/backend/src/services/quizanswer.service.ts
@@ -609,7 +609,6 @@ export default class QuizAnswerService {
       }
     }
 
-    console.log("SQL: ", queryBuilder.getQueryAndParameters())
     return queryBuilder
   }
 

--- a/packages/backend/src/services/validation.service.ts
+++ b/packages/backend/src/services/validation.service.ts
@@ -310,11 +310,8 @@ export default class ValidationService {
         // if the cause for manual review was too low an average,
         // their answer has a chance to be confirmed if their new average
         // is good enough
-        // Of course it could be that an answer should remain in this state,
-        // which is also probable since they are unlikely to receive further
-        // peer reviews...
         (quizAnswer.status === "manual-review" &&
-          userQuizState.spamFlags <= course.maxSpamFlags)) &&
+          userQuizState.spamFlags < 1)) &&
       given >= course.minPeerReviewsGiven &&
       received >= course.minPeerReviewsReceived &&
       quiz.autoConfirm

--- a/packages/dashboard/src/components/Answers/Answer.tsx
+++ b/packages/dashboard/src/components/Answers/Answer.tsx
@@ -31,6 +31,8 @@ class Answer extends React.Component<any, any> {
     confirmed: "#48fa5d",
     rejected: "#d80027",
     deprecated: "#9b9b9b",
+    "enough-received-but-not-given": "#FB6949",
+    "manual-review": "#FB6949",
   }
 
   constructor(props) {


### PR DESCRIPTION
Review changes: 
* New status option for quiz answer: 'manual-review'
  -  only used if the quiz has autoReject = false
  - answer enters the state if it has been flagged as spam before confirmation, or if the average of the required peer reviews is too low
  - answer can become automatically confirmed if the review average becomes high enough with more peer reviews (only if 0 spam flags still)
  -  Related queries use the new enum value
* Your answer will be shown to others as a peer review option only if you have given the required number of peer reviews

Other changes: 
- when calculating the attention-requiring answer counts, only the quizzes on permitted courses (where the user has some role / all courses if admin) are considered. Should cut down the longish count request for non-admins. 