### PR TITLE
Fix user course part generation

### DIFF
--- a/packages/backendv2/src/models/user_course_part_state.ts
+++ b/packages/backendv2/src/models/user_course_part_state.ts
@@ -79,18 +79,19 @@ class UserCoursePartState extends BaseModel {
         .where("course_id", courseId)
         .andWhereNot("part", 0)
         .groupBy("part")
-      const userCoursePartStates = parts.map(
+
+      const userCoursePartStateUpsertObjects = parts.map(
         ({ course_part, points_awarded, total_points }) => {
-          return this.fromJson({
+          return {
             userId,
             courseId,
             coursePart: course_part,
             score: points_awarded || 0,
             progress: total_points === 0 ? 0 : points_awarded / total_points,
-          })
+          }
         },
       )
-      await this.query(trx).insert(userCoursePartStates)
+      await this.query(trx).upsertGraph(userCoursePartStateUpsertObjects)
     } else {
       const { pointsAwarded, totalPoints } = (
         await trx("quiz")

--- a/packages/backendv2/src/models/user_course_part_state.ts
+++ b/packages/backendv2/src/models/user_course_part_state.ts
@@ -83,9 +83,9 @@ class UserCoursePartState extends BaseModel {
       const userCoursePartStateUpsertObjects = parts.map(
         ({ course_part, points_awarded, total_points }) => {
           return {
-            userId,
-            courseId,
-            coursePart: course_part,
+            user_id: userId,
+            course_id: courseId,
+            course_part: course_part,
             score: points_awarded || 0,
             progress: total_points === 0 ? 0 : points_awarded / total_points,
           }


### PR DESCRIPTION
Previous implementation crashed with a duplicate primary key error

Example schenario:

1. Course has only one part (part 1)
2. User answers to a quiz in part 1
3. Someone creates a new part (part 2)
4. User answers a quiz in part 2 -> duplicate primary key