### PR TITLE
don't use cached store

### DIFF
--- a/packages/moocfi-quizzes/src/components/QuizImpl/index.tsx
+++ b/packages/moocfi-quizzes/src/components/QuizImpl/index.tsx
@@ -165,7 +165,7 @@ interface SubmitMessageProps {
 const SubmitMessage = styled.div<SubmitMessageProps>`
   border-left: 6px solid #047500;
   padding: 0.25rem 0 0 1rem;
-  margin 0 0 3rem 0;
+  margin: 0 0 3rem 0;
   p {
     margin: 1rem 0px !important;
   }
@@ -204,6 +204,7 @@ const FuncQuizImpl: React.FunctionComponent<QuizProps> = ({
   const languageInfo = useTypedSelector(state => state.language.languageLabels)
   const userQuizState = useTypedSelector(state => state.user.userQuizState)
   const storeAccessToken = useTypedSelector(state => state.user.accessToken)
+
   const quizDisabled = useTypedSelector(state => state.quizAnswer.quizDisabled)
   const showPoints = useTypedSelector(
     state => state.customization.showPointsInfo,

--- a/packages/moocfi-quizzes/src/components/index.tsx
+++ b/packages/moocfi-quizzes/src/components/index.tsx
@@ -4,11 +4,11 @@ import { ThemeProvider } from "@material-ui/styles"
 import { QuizProps } from "./QuizImpl"
 import QuizImpl from "./QuizImpl"
 import { Provider } from "react-redux"
-import createStoreInstance from "../state/store"
+import { createStoreCreator } from "../state/store"
 import quizzesTheme from "../themes"
 
 const Quiz: React.FunctionComponent<QuizProps> = props => {
-  const store = createStoreInstance(props.id)
+  const store = createStoreCreator()
 
   return (
     <Provider store={store}>

--- a/packages/moocfi-quizzes/src/state/store.ts
+++ b/packages/moocfi-quizzes/src/state/store.ts
@@ -109,16 +109,6 @@ const rootReducer = combineReducers({
   user: userReducer,
 })
 
-/*const rootReducerD: typeof rootReducerImpl = (state, action) => {
-  if (action.type === "CLEAR") {
-    // @ts-ignore
-    const bestState: State = undefined
-
-    return bestState
-  }
-  return rootReducerImpl(state, action)
-}*/
-
 export const rootAction = {
   rootAction: rootActions,
   backendAction: backendAddressActions,
@@ -177,7 +167,7 @@ const createStoreInstance = (id: string): Store => {
   return store
 }
 
-const createStoreCreator = () => {
+export const createStoreCreator = () => {
   return createStore(rootReducer, composeWithDevTools(applyMiddleware(thunk)))
 }
 


### PR DESCRIPTION
Should close #716 

New store is already created when access token changes.
The change here is that a cached store is not used (if that was intended).