### PR TITLE
Fix adding peer reviews from dashboard

### DIFF
--- a/packages/quizzes-dashboard/store/editor/quiz/quizReducer.ts
+++ b/packages/quizzes-dashboard/store/editor/quiz/quizReducer.ts
@@ -149,7 +149,9 @@ export const quizReducer = createReducer<
 
   .handleAction(createdNewPeerReview, (state, action) => {
     return produce(state, draftState => {
-      draftState[action.payload.quizId].peerReviews.push(action.payload.newId)
+      draftState[action.payload.quizId].peerReviewCollections.push(
+        action.payload.newId,
+      )
     })
   })
 

--- a/packages/quizzes-dashboard/types/NormalizedQuiz.d.ts
+++ b/packages/quizzes-dashboard/types/NormalizedQuiz.d.ts
@@ -34,7 +34,7 @@ export interface NormalizedQuiz {
   grantPointsPolicy: string
   autoReject: boolean
   items: string[]
-  peerReviews: any[]
+  peerReviewCollections: any[]
   course: string
   title: string
   body: string


### PR DESCRIPTION
quizReducer had old name peerReviews, which was changed to peerReviewCollections in other places