### PR TITLE
Add locale for multiple choice dropdown's label

### DIFF
--- a/packages/moocfi-quizzes/src/components/MultipleChoiceDropdown/AnswerComponent.tsx
+++ b/packages/moocfi-quizzes/src/components/MultipleChoiceDropdown/AnswerComponent.tsx
@@ -45,10 +45,15 @@ const AnswerComponent = ({
   // This does not support selecting multiple options at the moment.
   const selectedOption = selectedOptionIds[0]
 
+  const languageLabels = useTypedSelector(
+    state => state.language.languageLabels,
+  )
+  const multipleChoiceLabels = languageLabels?.multipleChoice
+
   return (
     <>
       <InputLabel id="demo-simple-select-outlined-label">
-        select an option
+        {multipleChoiceLabels?.selectOption}
       </InputLabel>
       <StyledSelect
         labelId="demo-simple-select-outlined-label"

--- a/packages/moocfi-quizzes/src/utils/languages/COPY_AND_USE_AS_TEMPLATE.ts
+++ b/packages/moocfi-quizzes/src/utils/languages/COPY_AND_USE_AS_TEMPLATE.ts
@@ -86,6 +86,7 @@ const finnishLabels: SingleLanguageLabels = {
     chooseAllSuitableOptionsLabel: "Valitse kaikki sopivat vaihtoehdot.",
     answerCorrectLabel: "Oikein",
     answerIncorrectLabel: "Väärin",
+    selectOption: "valitse vaihtoehto",
   },
   stage: {
     answerStageLabel: "Tehtävään vastaaminen",

--- a/packages/moocfi-quizzes/src/utils/languages/bulgarian_options.ts
+++ b/packages/moocfi-quizzes/src/utils/languages/bulgarian_options.ts
@@ -84,6 +84,7 @@ const bulgarianLabels: SingleLanguageLabels = {
     chooseAllSuitableOptionsLabel: "Изберете всички приложими отговори",
     answerCorrectLabel: "Правилен отговор",
     answerIncorrectLabel: "Неправилен отговор",
+    selectOption: "select an option",
   },
   stage: {
     answerStageLabel: "Отговор на упражнението",

--- a/packages/moocfi-quizzes/src/utils/languages/croatian_options.ts
+++ b/packages/moocfi-quizzes/src/utils/languages/croatian_options.ts
@@ -88,6 +88,7 @@ const croatianLabels: SingleLanguageLabels = {
     chooseAllSuitableOptionsLabel: "Označite sve moguće odgovore.",
     answerCorrectLabel: "Točno.",
     answerIncorrectLabel: "Netočno.",
+    selectOption: "select an option",
   },
   stage: {
     answerStageLabel: "U tijeku je rješavanje zadatka",

--- a/packages/moocfi-quizzes/src/utils/languages/czech_options.ts
+++ b/packages/moocfi-quizzes/src/utils/languages/czech_options.ts
@@ -82,6 +82,7 @@ const czechLabels: SingleLanguageLabels = {
     chooseAllSuitableOptionsLabel: "Vybrat všechny vhodné možnosti",
     answerCorrectLabel: "Správně",
     answerIncorrectLabel: "Špatně",
+    selectOption: "select an option",
   },
   stage: {
     answerStageLabel: "Plnění úkolu",

--- a/packages/moocfi-quizzes/src/utils/languages/danish_options.ts
+++ b/packages/moocfi-quizzes/src/utils/languages/danish_options.ts
@@ -86,6 +86,7 @@ const danishLabels: SingleLanguageLabels = {
     chooseAllSuitableOptionsLabel: "Der kan vælges flere svar.",
     answerCorrectLabel: "Korrekt",
     answerIncorrectLabel: "Forkert",
+    selectOption: "select an option",
   },
   stage: {
     answerStageLabel: "Besvarelse af øvelsen",

--- a/packages/moocfi-quizzes/src/utils/languages/dutch_options.ts
+++ b/packages/moocfi-quizzes/src/utils/languages/dutch_options.ts
@@ -85,6 +85,7 @@ const dutchLabels: SingleLanguageLabels = {
     chooseAllSuitableOptionsLabel: "Meer dan één antwoord mogelijk",
     answerCorrectLabel: "Juist",
     answerIncorrectLabel: "Onjuist",
+    selectOption: "select an option",
   },
   stage: {
     answerStageLabel: "Oefening aan het beantwoorden",

--- a/packages/moocfi-quizzes/src/utils/languages/english_options.ts
+++ b/packages/moocfi-quizzes/src/utils/languages/english_options.ts
@@ -84,6 +84,7 @@ const englishLabels: SingleLanguageLabels = {
     chooseAllSuitableOptionsLabel: "Select all that apply",
     answerCorrectLabel: "Correct",
     answerIncorrectLabel: "Incorrect",
+    selectOption: "select an option",
   },
   stage: {
     answerStageLabel: "Answering the exercise",

--- a/packages/moocfi-quizzes/src/utils/languages/estonian_options.ts
+++ b/packages/moocfi-quizzes/src/utils/languages/estonian_options.ts
@@ -84,6 +84,7 @@ const estonianLabels: SingleLanguageLabels = {
     chooseAllSuitableOptionsLabel: "vali kõik, mis sobivad.",
     answerCorrectLabel: "Õige",
     answerIncorrectLabel: "Vale",
+    selectOption: "select an option",
   },
   stage: {
     answerStageLabel: "Harjutusele vastamine",

--- a/packages/moocfi-quizzes/src/utils/languages/finnish_options.ts
+++ b/packages/moocfi-quizzes/src/utils/languages/finnish_options.ts
@@ -86,6 +86,7 @@ const finnishLabels: SingleLanguageLabels = {
     chooseAllSuitableOptionsLabel: "Valitse kaikki sopivat vaihtoehdot.",
     answerCorrectLabel: "Oikein",
     answerIncorrectLabel: "Väärin",
+    selectOption: "valitse vaihtoehto",
   },
   stage: {
     answerStageLabel: "Tehtävään vastaaminen",

--- a/packages/moocfi-quizzes/src/utils/languages/french_options.ts
+++ b/packages/moocfi-quizzes/src/utils/languages/french_options.ts
@@ -94,6 +94,7 @@ const frenchLabels: SingleLanguageLabels = {
       "Sélectionnez toutes les options appropriées",
     answerCorrectLabel: "Correcte",
     answerIncorrectLabel: "Incorrecte",
+    selectOption: "select an option",
   },
   stage: {
     answerStageLabel: "Répondre au quiz",

--- a/packages/moocfi-quizzes/src/utils/languages/german_options.ts
+++ b/packages/moocfi-quizzes/src/utils/languages/german_options.ts
@@ -89,6 +89,7 @@ const germanLabels: SingleLanguageLabels = {
     chooseAllSuitableOptionsLabel: "Bitte wähle alle passenden Alternativen.",
     answerCorrectLabel: "Richtig",
     answerIncorrectLabel: "Falsch",
+    selectOption: "select an option",
   },
   stage: {
     answerStageLabel: "Beantworten der Übung",

--- a/packages/moocfi-quizzes/src/utils/languages/greek_options.ts
+++ b/packages/moocfi-quizzes/src/utils/languages/greek_options.ts
@@ -91,6 +91,7 @@ const greekLabels: SingleLanguageLabels = {
     chooseAllSuitableOptionsLabel: "Επιλέξτε όλα όσα ισχύουν",
     answerCorrectLabel: "Σωστό",
     answerIncorrectLabel: "Λάθος",
+    selectOption: "select an option",
   },
   stage: {
     answerStageLabel: "Απάντηση στην άσκηση",

--- a/packages/moocfi-quizzes/src/utils/languages/hungarian_options.ts
+++ b/packages/moocfi-quizzes/src/utils/languages/hungarian_options.ts
@@ -85,6 +85,7 @@ const hungarianLabels: SingleLanguageLabels = {
       "Kérjük, jelölje be az összes megfelelő választ",
     answerCorrectLabel: "Helyes",
     answerIncorrectLabel: "Helytelen",
+    selectOption: "select an option",
   },
   stage: {
     answerStageLabel: "A feladat megválaszolása",

--- a/packages/moocfi-quizzes/src/utils/languages/icelandic_options.ts
+++ b/packages/moocfi-quizzes/src/utils/languages/icelandic_options.ts
@@ -87,6 +87,7 @@ const icelandicLabels: SingleLanguageLabels = {
     chooseAllSuitableOptionsLabel: "Veldu allt sem við á",
     answerCorrectLabel: "Rétt",
     answerIncorrectLabel: "Rangt",
+    selectOption: "select an option",
   },
   stage: {
     answerStageLabel: "Svarar æfingunni",

--- a/packages/moocfi-quizzes/src/utils/languages/index.ts
+++ b/packages/moocfi-quizzes/src/utils/languages/index.ts
@@ -69,6 +69,7 @@ export type MultipleChoiceLabels = {
   chooseAllSuitableOptionsLabel: string
   answerCorrectLabel: string
   answerIncorrectLabel: string
+  selectOption: string
 }
 
 export type EssayLabels = {

--- a/packages/moocfi-quizzes/src/utils/languages/irish_options.ts
+++ b/packages/moocfi-quizzes/src/utils/languages/irish_options.ts
@@ -89,6 +89,7 @@ const irishLabels: SingleLanguageLabels = {
     chooseAllSuitableOptionsLabel: "Roghnaigh gach ceann is infheidhme.",
     answerCorrectLabel: "Ceart",
     answerIncorrectLabel: "Mícheart",
+    selectOption: "select an option",
   },
   stage: {
     answerStageLabel: "An cleachtadh á fhreagairt",

--- a/packages/moocfi-quizzes/src/utils/languages/italian_options.ts
+++ b/packages/moocfi-quizzes/src/utils/languages/italian_options.ts
@@ -89,6 +89,7 @@ const italianLabels: SingleLanguageLabels = {
     chooseAllSuitableOptionsLabel: "Più risposte possibili",
     answerCorrectLabel: "Esatto",
     answerIncorrectLabel: "Sbagliato",
+    selectOption: "select an option",
   },
   stage: {
     answerStageLabel: "Fare l'esercizio",

--- a/packages/moocfi-quizzes/src/utils/languages/latvian_options.ts
+++ b/packages/moocfi-quizzes/src/utils/languages/latvian_options.ts
@@ -84,6 +84,7 @@ const latvianLabels: SingleLanguageLabels = {
     chooseAllSuitableOptionsLabel: "Atlasiet visu attiecīgo!",
     answerCorrectLabel: "Pareizi",
     answerIncorrectLabel: "Nepareizi",
+    selectOption: "select an option",
   },
   stage: {
     answerStageLabel: "Atbildēšana uz uzdevumu",

--- a/packages/moocfi-quizzes/src/utils/languages/lithuanian_options.ts
+++ b/packages/moocfi-quizzes/src/utils/languages/lithuanian_options.ts
@@ -88,6 +88,7 @@ const lithuanianLabels: SingleLanguageLabels = {
     chooseAllSuitableOptionsLabel: "Pasirinkite visus tinkamus atsakymus.",
     answerCorrectLabel: "Teisinga",
     answerIncorrectLabel: "Neteisinga",
+    selectOption: "select an option",
   },
   stage: {
     answerStageLabel: "Teikiamas pratimo atsakymas",

--- a/packages/moocfi-quizzes/src/utils/languages/maltese_options.ts
+++ b/packages/moocfi-quizzes/src/utils/languages/maltese_options.ts
@@ -88,6 +88,7 @@ const malteseLabels: SingleLanguageLabels = {
     chooseAllSuitableOptionsLabel: "Agħżel dawk kollha li japplikaw",
     answerCorrectLabel: "Korretta",
     answerIncorrectLabel: "Żbaljata",
+    selectOption: "select an option",
   },
   stage: {
     answerStageLabel: "Naħdmu l-eżerċizzju",

--- a/packages/moocfi-quizzes/src/utils/languages/norwegian_options.ts
+++ b/packages/moocfi-quizzes/src/utils/languages/norwegian_options.ts
@@ -88,6 +88,7 @@ const norwegianLabels: SingleLanguageLabels = {
     chooseAllSuitableOptionsLabel: "Velg  riktige påstander",
     answerCorrectLabel: "Korrekt",
     answerIncorrectLabel: "Galt",
+    selectOption: "select an option",
   },
   stage: {
     answerStageLabel: "Å svare på oppgaven",

--- a/packages/moocfi-quizzes/src/utils/languages/polish_options.ts
+++ b/packages/moocfi-quizzes/src/utils/languages/polish_options.ts
@@ -81,6 +81,7 @@ const polishLabels: SingleLanguageLabels = {
     chooseAllSuitableOptionsLabel: "Zaznacz wszystkie pasujące odpowiedzi",
     answerCorrectLabel: "Odpowiedź prawidłowa",
     answerIncorrectLabel: "Odpowiedź nieprawidłowa",
+    selectOption: "select an option",
   },
   stage: {
     answerStageLabel: "Rozwiązywanie ćwiczenia",

--- a/packages/moocfi-quizzes/src/utils/languages/portuguese_options.ts
+++ b/packages/moocfi-quizzes/src/utils/languages/portuguese_options.ts
@@ -91,6 +91,7 @@ const portugueseLabels: SingleLanguageLabels = {
     chooseAllSuitableOptionsLabel: "Selecione todas as opções aplicáveis",
     answerCorrectLabel: "Correto",
     answerIncorrectLabel: "Incorreto",
+    selectOption: "select an option",
   },
   stage: {
     answerStageLabel: "A responder ao exercício",

--- a/packages/moocfi-quizzes/src/utils/languages/romanian_options.ts
+++ b/packages/moocfi-quizzes/src/utils/languages/romanian_options.ts
@@ -88,6 +88,7 @@ const romanianLabels: SingleLanguageLabels = {
     chooseAllSuitableOptionsLabel: "Selectați toate variantele aplicabile.",
     answerCorrectLabel: "Corect",
     answerIncorrectLabel: "Inorect",
+    selectOption: "select an option",
   },
   stage: {
     answerStageLabel: "Se transmit răspunsurile la exercițiu",

--- a/packages/moocfi-quizzes/src/utils/languages/slovak_options.ts
+++ b/packages/moocfi-quizzes/src/utils/languages/slovak_options.ts
@@ -83,6 +83,7 @@ const slovakLabels: SingleLanguageLabels = {
     chooseAllSuitableOptionsLabel: "Vyberať všetky vhodné možnosti",
     answerCorrectLabel: "Správne",
     answerIncorrectLabel: "Nesprávne",
+    selectOption: "select an option",
   },
   stage: {
     answerStageLabel: "Práca na cvičení",

--- a/packages/moocfi-quizzes/src/utils/languages/slovenian_options.ts
+++ b/packages/moocfi-quizzes/src/utils/languages/slovenian_options.ts
@@ -83,6 +83,7 @@ const slovenianLabels: SingleLanguageLabels = {
     chooseAllSuitableOptionsLabel: "Izberite vse relevantne možnosti",
     answerCorrectLabel: "Pravilno",
     answerIncorrectLabel: "Napačno",
+    selectOption: "select an option",
   },
   stage: {
     answerStageLabel: "Izpolnjevanje naloge",

--- a/packages/moocfi-quizzes/src/utils/languages/spanish_options.ts
+++ b/packages/moocfi-quizzes/src/utils/languages/spanish_options.ts
@@ -85,6 +85,7 @@ const spanishLabels: SingleLanguageLabels = {
     chooseAllSuitableOptionsLabel: "Seleccionar todas las aplicables",
     answerCorrectLabel: "Correcto",
     answerIncorrectLabel: "Incorrecto",
+    selectOption: "select an option",
   },
   stage: {
     answerStageLabel: "Respondiendo al ejercicio",

--- a/packages/moocfi-quizzes/src/utils/languages/swedish_options.ts
+++ b/packages/moocfi-quizzes/src/utils/languages/swedish_options.ts
@@ -89,6 +89,7 @@ const swedishLabels: SingleLanguageLabels = {
     chooseAllSuitableOptionsLabel: "Välj alla passande alternativ",
     answerCorrectLabel: "Rätt",
     answerIncorrectLabel: "Fel",
+    selectOption: "välj ett alternativ",
   },
   stage: {
     answerStageLabel: "Att ge svar på uppgiften",


### PR DESCRIPTION
Added a locale for MultipleChoiceDropdown/AnswerComponent's label, that previously had hard-coded text "select an opinion".

Currently adding only locales for English, Finnish and Swedish, as these are needed for Ethics of AI's new language versions that launch next week. The other languages will still have the english text on the label.

Images of the component in question:

![multiplechoice1](https://user-images.githubusercontent.com/10534869/142391707-ebca31d5-af09-472c-9400-48219b9b97a9.png)
![multiplechoice2](https://user-images.githubusercontent.com/10534869/142391703-9c84b565-4668-435e-9923-2b7680fac9eb.png)


