### PR TITLE
when pushing quiz answer to kafka, also include original creation date

### DIFF
--- a/packages/backend/src/scripts/kafka_batch_publisher.ts
+++ b/packages/backend/src/scripts/kafka_batch_publisher.ts
@@ -235,9 +235,10 @@ const publishAnswers = async (course: ICourse, userId?: string) => {
       ])
       .as("latest")
 
-    const answersQuery = knex("user_quiz_state")
+    const answersQuery = knex<any, IPublishQuizAnswer>("user_quiz_state")
       .select([
         "quiz_answer.quiz_id",
+        "quiz_answer.created_at",
         "user_quiz_state.points_awarded",
         "quiz_answer.status",
         "quiz_answer.user_id",
@@ -259,7 +260,7 @@ const publishAnswers = async (course: ICourse, userId?: string) => {
       answersQuery.andWhere("quiz_answer.user_id", userId)
     }
 
-    const answers = await answersQuery
+    const answers: IPublishQuizAnswer[] = await answersQuery
 
     let answer
 
@@ -279,6 +280,7 @@ const publishAnswers = async (course: ICourse, userId?: string) => {
 
       const message: QuizAnswerMessage = {
         timestamp: new Date().toISOString(),
+        original_submission_date: answer.created_at,
         exercise_id: answer.quiz_id,
         n_points: answer.excluded_from_score ? 0 : answer.points_awarded || 0,
         completed: answer.status === "confirmed",
@@ -429,6 +431,18 @@ interface IQuiz {
   auto_confirm: boolean
   excluded_from_score: boolean
   grantPointsPolicy: any
+}
+
+interface IPublishQuizAnswer {
+  quiz_id: string
+  created_at: string
+  points_awarded: number
+  status: string
+  user_id: number
+  types: string[]
+  peer_reviews_given: number
+  peer_reviews_received: number
+  excluded_from_score: boolean
 }
 
 producer.on("ready", publish)

--- a/packages/backend/src/services/kafka.service.ts
+++ b/packages/backend/src/services/kafka.service.ts
@@ -89,6 +89,7 @@ export default class KafkaService {
 
     const message: QuizAnswerMessage = {
       timestamp: new Date().toISOString(),
+      original_submission_date: quizAnswer.createdAt.toISOString(),
       exercise_id: quizAnswer.quizId,
       n_points: quiz.excludedFromScore ? 0 : userQuizState.pointsAwarded,
       completed: quizAnswer.status === "confirmed",

--- a/packages/backend/src/types/index.d.ts
+++ b/packages/backend/src/types/index.d.ts
@@ -227,6 +227,7 @@ export interface QuizAnswerMessage {
   service_id: string
   required_actions: RequiredAction[] | null
   message_format_version: number
+  original_submission_date: string | null
   attempted: boolean
 }
 

--- a/packages/backendv2/src/services/kafka.ts
+++ b/packages/backendv2/src/services/kafka.ts
@@ -68,6 +68,7 @@ export const broadcastQuizAnswerUpdated = async (
 
   const message: QuizAnswerMessage = {
     timestamp: new Date().toISOString(),
+    original_submission_date: quizAnswer.createdAt,
     exercise_id: quizAnswer.quizId,
     n_points: quiz.excludedFromScore ? 0 : userQuizState.pointsAwarded ?? 0,
     completed: quizAnswer.status === "confirmed",

--- a/packages/backendv2/src/types/index.ts
+++ b/packages/backendv2/src/types/index.ts
@@ -56,6 +56,7 @@ export interface QuizAnswerMessage {
   required_actions: RequiredAction[] | null
   message_format_version: number
   attempted: boolean
+  original_submission_date: string | null
 }
 
 export interface QuizMessage {

--- a/packages/moocfi-quizzes/src/modelTypes.ts
+++ b/packages/moocfi-quizzes/src/modelTypes.ts
@@ -225,4 +225,5 @@ export interface QuizAnswerMessage {
   service_id: string
   required_actions: string[] | null
   message_format_version: number
+  original_submission_date: string | null
 }


### PR DESCRIPTION
MOOC.fi has had `original_submission_date` field in `exercise_completion` and Kafka message format for a long time now, but they haven't been utilized. This should include the original `quiz_answer` creation time as the submission date in future messages.