### PR TITLE
kafka_batch_publisher pushes points one user at a time

### DIFF
--- a/packages/backend/src/scripts/kafka_batch_publisher.ts
+++ b/packages/backend/src/scripts/kafka_batch_publisher.ts
@@ -75,13 +75,9 @@ const publish = async () => {
               await publishProgress(course, quizzes, user_id)
 
               console.log("publishing answers for user: " + user_id)
-              if (USE_USER_POINTS_BATCH) {
-                await publishCourseAnswers(course, user_id, {
-                  useUserPointsBatch: true,
-                })
-              } else {
-                await publishCourseAnswers(course, user_id)
-              }
+              await publishCourseAnswers(course, user_id, {
+                useUserPointsBatch: USE_USER_POINTS_BATCH,
+              })
             } else {
               console.log("publishing quizzes")
               const quizzes = await publishQuizzes(course)
@@ -90,11 +86,9 @@ const publish = async () => {
               await publishProgress(course, quizzes)
 
               console.log("publishing answers")
-              if (USE_USER_POINTS_BATCH) {
-                await publishCourseAnswers(course, { useUserPointsBatch: true })
-              } else {
-                await publishCourseAnswers(course)
-              }
+              await publishCourseAnswers(course, {
+                useUserPointsBatch: USE_USER_POINTS_BATCH,
+              })
             }
           } else {
             console.error("No moocfi_id for task. Aborting.")

--- a/packages/backend/src/scripts/kafka_batch_publisher.ts
+++ b/packages/backend/src/scripts/kafka_batch_publisher.ts
@@ -380,8 +380,7 @@ const publishCourseAnswers = async (
       answererIds = [userId]
     } else {
       const uniqueAnswerers = await knex("quiz_answer")
-        .select("user_id")
-        .distinctOn("user_id")
+        .distinct("user_id")
         .join("quiz", { "quiz_answer.quiz_id": "quiz.id" })
         .where("quiz.course_id", courseId)
         .whereNotNull("user_id")

--- a/packages/backend/src/types/index.d.ts
+++ b/packages/backend/src/types/index.d.ts
@@ -231,6 +231,14 @@ export interface QuizAnswerMessage {
   attempted: boolean
 }
 
+export interface CourseQuizAnswersMessage {
+  timestamp: string
+  user_id: number
+  course_id: string
+  exercises: QuizAnswerMessage[]
+  message_format_version: number
+}
+
 export interface QuizMessage {
   timestamp: string
   course_id: string


### PR DESCRIPTION
Use the new `user-course-points-batch` topic to speed up syncing: push all the exercise completions for given user in one message. Also pushes not attempted exercises. 

Uses the old `user-points-batch` if `USE_USER_POINTS_BATCH` env is set to `true`. Also changed that to push not attempted exercises.